### PR TITLE
fix: rename duplicate CI workflow job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    name: Lint and Format Check
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
         run: pnpm run lint:eslint
 
   format:
-    name: Lint and Format Check
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Renamed the `lint` job from "Lint and Format Check" to "Lint"
- Renamed the `format` job from "Lint and Format Check" to "Format"

This resolves the confusion caused by having two jobs with identical display names, which was causing issues with tooling. The word "Check" was also removed as it was redundant.

## Test plan
- Verify that CI jobs still run correctly with the new names
- Check that GitHub Actions UI displays distinct job names

🤖 Generated with [Claude Code](https://claude.com/claude-code)