### PR TITLE
feat: add Next.js bundle analysis plugin

### DIFF
--- a/docs/bundler-integration/NEXTJS.md
+++ b/docs/bundler-integration/NEXTJS.md
@@ -2,6 +2,29 @@
 
 This document describes how to integrate bundle analysis with Next.js using webpack configuration.
 
+## Smappy Next.js Plugin
+
+We provide a helper that wires the bundle analysis plugin into Next.js builds for both client and server targets:
+
+```javascript
+// next.config.js
+import { withNextBundleAnalysis } from '../src/lib/server/plugins/nextjs/index.js';
+
+export default withNextBundleAnalysis(
+  {
+    reactStrictMode: true,
+  },
+  {
+    projectName: 'my-nextjs-app',
+    extractSourceMaps: true,
+    analyzeClient: true,
+    analyzeServer: true,
+  },
+);
+```
+
+The helper automatically detects the build target (`client`, `server`, `edge`, or `middleware`) and attaches the correct plugin instance. For finer-grained control you can instantiate `NextJsBundleAnalysisPlugin` directly inside the `webpack` override.
+
 ## Next.js Webpack Configuration
 
 Next.js allows customizing webpack configuration via `next.config.js`.

--- a/src/lib/server/db/README.md
+++ b/src/lib/server/db/README.md
@@ -121,7 +121,7 @@ Each seed data profile returns `BundleIngestionInput` objects that match the str
 ```typescript
 interface BundleIngestionInput {
   options: {
-    bundlerType: 'vite' | 'webpack' | 'rollup' | 'esbuild' | 'parcel';
+    bundlerType: 'vite' | 'webpack' | 'rollup' | 'esbuild' | 'parcel' | 'nextjs';
     projectName: string;
     enableIncremental: boolean;
   };

--- a/src/lib/server/ingestion/types/index.ts
+++ b/src/lib/server/ingestion/types/index.ts
@@ -55,7 +55,7 @@ export interface ModuleInput {
  */
 export interface IngestionOptions {
   /** Type of bundler that generated this bundle */
-  bundlerType: 'webpack' | 'rollup' | 'esbuild' | 'vite' | 'parcel' | 'other';
+  bundlerType: 'webpack' | 'rollup' | 'esbuild' | 'vite' | 'parcel' | 'nextjs' | 'other';
   /** Name of the project being analyzed */
   projectName: string;
   /** Whether to perform incremental analysis */

--- a/src/lib/server/ingestion/types/types.spec.ts
+++ b/src/lib/server/ingestion/types/types.spec.ts
@@ -140,6 +140,7 @@ describe('Type definitions', () => {
         'esbuild',
         'vite',
         'parcel',
+        'nextjs',
         'other',
       ];
       types.forEach((bundlerType) => {

--- a/src/lib/server/plugins/angular/adapter.ts
+++ b/src/lib/server/plugins/angular/adapter.ts
@@ -373,7 +373,7 @@ export class AngularAdapter extends BundlerAdapter {
    * Create ingestion options
    */
   protected createIngestionOptions(
-    bundlerType: 'webpack' | 'rollup' | 'esbuild' | 'vite' | 'parcel' | 'other',
+    bundlerType: 'webpack' | 'rollup' | 'esbuild' | 'vite' | 'parcel' | 'nextjs' | 'other',
   ): IngestionOptions {
     return {
       bundlerType,

--- a/src/lib/server/plugins/index.ts
+++ b/src/lib/server/plugins/index.ts
@@ -40,3 +40,19 @@ export type { AdapterFactory } from './adapters.js';
 // Re-export Angular plugin
 export { AngularAdapter, angularBundleAnalysisBuilder } from './angular/index.js';
 export type { AngularBuilderOptions } from './angular/index.js';
+
+// Re-export Next.js plugin
+export {
+  NextJsBundleAnalysisPlugin,
+  nextJsBundleAnalysisPlugin,
+  withNextBundleAnalysis,
+} from './nextjs/index.js';
+export type {
+  NextJsPluginOptions,
+  WithNextBundleAnalysisOptions,
+  NextConfig as NextBundleAnalysisConfig,
+  NextWebpackBuildContext,
+  NextJsBuildTarget,
+  NextJsRuntime,
+} from './nextjs/index.js';
+export { NextJsAdapter } from './nextjs/index.js';

--- a/src/lib/server/plugins/nextjs/adapter.spec.ts
+++ b/src/lib/server/plugins/nextjs/adapter.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for Next.js adapter
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Compilation, Stats } from 'webpack';
+import { NextJsAdapter, sanitizeModuleIdentifier } from './adapter.js';
+import type { NextJsAdapterOptions } from './adapter.js';
+
+describe('NextJsAdapter', () => {
+  const baseDir = '/project';
+  const baseOptions: NextJsAdapterOptions = {
+    projectName: 'test-next-app',
+    buildTarget: 'client',
+  };
+
+  it('should report errors for invalid input and set bundler type to nextjs', () => {
+    const adapter = new NextJsAdapter(baseDir, baseOptions);
+    const result = adapter.extract(null);
+
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.options.bundlerType).toBe('nextjs');
+  });
+
+  it('should sanitize Next.js module identifiers and chunk metadata', () => {
+    const adapter = new NextJsAdapter(baseDir, baseOptions);
+
+    const mockStats = {
+      toJson: () => ({
+        modules: [
+          {
+            identifier: './app/page.tsx?__next_rsc__',
+            name: './app/page.tsx?__next_rsc__',
+            size: 420,
+            reasons: [],
+          },
+          {
+            identifier:
+              'next-flight-client-entry-loader?modules=app%2Fproducts%2F%5Bid%5D%2Fpage.tsx',
+            name: 'next-flight-client-entry-loader?modules=app%2Fproducts%2F%5Bid%5D%2Fpage.tsx',
+            size: 1024,
+            reasons: [],
+          },
+        ],
+        chunks: [
+          {
+            id: 0,
+            names: ['app/page'],
+            files: ['static/chunks/app/page.js'],
+            modules: [
+              {
+                identifier: './app/page.tsx?__next_rsc__',
+                name: './app/page.tsx?__next_rsc__',
+              },
+              {
+                identifier:
+                  'next-flight-client-entry-loader?modules=app%2Fproducts%2F%5Bid%5D%2Fpage.tsx',
+                name: 'next-flight-client-entry-loader?modules=app%2Fproducts%2F%5Bid%5D%2Fpage.tsx',
+              },
+            ],
+            entry: true,
+            initial: true,
+            async: false,
+            size: 1440,
+          },
+        ],
+        assets: [
+          {
+            name: 'static/chunks/app/page.js',
+            size: 3500,
+          },
+        ],
+      }),
+      compilation: {} as Compilation,
+    } as unknown as Stats;
+
+    const nextOutput = {
+      stats: mockStats,
+      compilation: mockStats.compilation,
+      outputPath: '/project/.next',
+    };
+
+    const result = adapter.extract(nextOutput);
+
+    expect(result.options.bundlerType).toBe('nextjs');
+    expect(result.errors).toEqual([]);
+
+    const modulePaths = result.modules.map((module) => module.filePath);
+    expect(modulePaths).toContain('project/app/page.tsx');
+    expect(modulePaths).toContain('project/app/products/[id]/page.tsx');
+
+    const chunk = result.chunks[0];
+    expect(chunk.moduleIds).toContain('project/app/page.tsx');
+    expect(chunk.moduleIds).toContain('project/app/products/[id]/page.tsx');
+
+    const bundle = result.bundles[0];
+    expect(bundle.fileName).toBe('static/chunks/app/page.js');
+  });
+
+  it('should normalize identifiers exported from helper function', () => {
+    expect(
+      sanitizeModuleIdentifier(
+        'next-client-pages-loader?absolutePagePath=%2Fproject%2Fpages%2Fapi%2Fhello.ts&page=/api/hello',
+      ),
+    ).toBe('project/pages/api/hello.ts');
+  });
+});

--- a/src/lib/server/plugins/nextjs/adapter.ts
+++ b/src/lib/server/plugins/nextjs/adapter.ts
@@ -1,0 +1,318 @@
+/**
+ * Next.js adapter built on top of the webpack adapter
+ * Provides Next-specific normalization for module identifiers and bundles
+ */
+
+import { extname } from 'node:path';
+import type {
+  BundlerBundle,
+  BundlerChunk,
+  BundlerModule,
+  BundlerPluginOptions,
+  PluginConfig,
+  PluginExtractionResult,
+} from '../types.js';
+import { WebpackAdapter } from '../webpack/adapter.js';
+
+/**
+ * Supported Next.js build targets
+ */
+export type NextJsBuildTarget = 'client' | 'server' | 'edge' | 'middleware';
+
+/**
+ * Supported Next.js runtimes
+ */
+export type NextJsRuntime = 'nodejs' | 'edge';
+
+/**
+ * Options for the Next.js adapter
+ */
+export interface NextJsAdapterOptions extends BundlerPluginOptions {
+  buildTarget: NextJsBuildTarget;
+  runtime?: NextJsRuntime;
+}
+
+/**
+ * Adapter for extracting bundle data from Next.js builds
+ * Extends the webpack adapter and adds Next-specific normalization
+ */
+export class NextJsAdapter extends WebpackAdapter {
+  private buildTarget: NextJsBuildTarget;
+  private runtime: NextJsRuntime;
+
+  constructor(baseDir: string, options: NextJsAdapterOptions, config?: PluginConfig) {
+    super(baseDir, options, config);
+    this.buildTarget = options.buildTarget;
+    this.runtime =
+      options.runtime ??
+      (options.buildTarget === 'edge' || options.buildTarget === 'middleware' ? 'edge' : 'nodejs');
+  }
+
+  /**
+   * Override extract to set bundler type to nextjs
+   */
+  extract(bundlerOutput: unknown): PluginExtractionResult {
+    const result = super.extract(bundlerOutput);
+
+    return {
+      ...result,
+      bundles: result.bundles.map((bundle) => ({
+        ...bundle,
+        fileName: sanitizeAssetPath(bundle.fileName, this.buildTarget),
+      })),
+      modules: result.modules.map((module) => ({
+        ...module,
+        filePath: toAbsoluteModuleId(sanitizeModuleIdentifier(module.filePath), this.baseDir),
+      })),
+      chunks: result.chunks.map((chunk) => ({
+        ...chunk,
+        name: sanitizeChunkName(chunk.name),
+        moduleIds: chunk.moduleIds.map((id) =>
+          toAbsoluteModuleId(sanitizeModuleIdentifier(id), this.baseDir),
+        ),
+      })),
+      options: {
+        ...result.options,
+        bundlerType: 'nextjs',
+      },
+    };
+  }
+
+  /**
+   * Normalize module identifiers before delegating to webpack adapter
+   */
+  protected convertModules(
+    bundlerModules: BundlerModule[],
+    errors: string[],
+  ): ReturnType<WebpackAdapter['convertModules']> {
+    const normalizedModules = bundlerModules.map((module) => ({
+      ...module,
+      identifier: sanitizeModuleIdentifier(module.identifier),
+      name: module.name ? sanitizeModuleIdentifier(module.name) : module.name,
+    }));
+
+    return super.convertModules(normalizedModules, errors);
+  }
+
+  /**
+   * Normalize chunk metadata before delegating
+   */
+  protected convertChunks(
+    bundlerChunks: BundlerChunk[],
+    errors: string[],
+  ): ReturnType<WebpackAdapter['convertChunks']> {
+    const normalizedChunks = bundlerChunks.map((chunk) => ({
+      ...chunk,
+      name: sanitizeChunkName(chunk.name),
+      modules: chunk.modules?.map((moduleId) =>
+        toAbsoluteModuleId(sanitizeModuleIdentifier(moduleId), this.baseDir),
+      ),
+    }));
+
+    return super.convertChunks(normalizedChunks, errors);
+  }
+
+  /**
+   * Normalize bundle file names before delegating
+   */
+  protected convertBundles(
+    bundlerBundles: BundlerBundle[],
+    errors: string[],
+  ): ReturnType<WebpackAdapter['convertBundles']> {
+    const normalizedBundles = bundlerBundles.map((bundle) => ({
+      ...bundle,
+      fileName: sanitizeAssetPath(bundle.fileName, this.buildTarget),
+    }));
+
+    return super.convertBundles(normalizedBundles, errors);
+  }
+}
+
+/**
+ * Determine if a path has a JavaScript or TypeScript extension
+ */
+function hasModuleExtension(path: string): boolean {
+  const extension = extname(path).toLowerCase();
+  return ['.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx'].includes(extension);
+}
+
+/**
+ * Normalize module identifiers by removing loader prefixes, query strings,
+ * and translating private Next.js internals to user-friendly paths.
+ */
+export function sanitizeModuleIdentifier(identifier: string): string {
+  if (!identifier) {
+    return identifier;
+  }
+
+  const withoutLoader = stripWebpackLoaders(identifier);
+  const { resourcePath, queryString } = splitResourceQuery(withoutLoader);
+
+  let normalized = normalizeInternalPath(resourcePath);
+
+  if (!hasModuleExtension(normalized) && queryString) {
+    const extracted = extractPathFromQuery(queryString);
+    if (extracted) {
+      normalized = normalizeInternalPath(extracted);
+    }
+  }
+
+  return normalized;
+}
+
+/**
+ * Sanitize bundle file paths to remove redundant prefixes
+ */
+function sanitizeAssetPath(fileName: string, target: NextJsBuildTarget): string {
+  if (!fileName) {
+    return fileName;
+  }
+
+  let sanitized = fileName.replace(/\\/g, '/');
+
+  sanitized = sanitized.replace(/^\.next\//, '');
+  sanitized = sanitized.replace(/^static\/chunks\/(webpack-[\w-]+)\.js$/, 'static/chunks/$1.js');
+  sanitized = sanitized.replace(/^server\/app\//, 'app/');
+  sanitized = sanitized.replace(/^server\/pages\//, 'pages/');
+
+  if (target === 'middleware' || target === 'edge') {
+    sanitized = sanitized.replace(/^server\/middleware\//, 'middleware/');
+  }
+
+  return sanitized;
+}
+
+/**
+ * Remove query decorations from chunk names
+ */
+function sanitizeChunkName(name: string): string {
+  if (!name) {
+    return name;
+  }
+  return name.split('?')[0];
+}
+
+/**
+ * Strip loader prefixes (webpack style loader!resource syntax)
+ */
+function stripWebpackLoaders(identifier: string): string {
+  const segments = identifier.split('!');
+  return segments[segments.length - 1] || identifier;
+}
+
+/**
+ * Split resource path from query string
+ */
+function splitResourceQuery(resource: string): { resourcePath: string; queryString?: string } {
+  const [pathPart, ...queryParts] = resource.split('?');
+  return {
+    resourcePath: pathPart,
+    queryString: queryParts.length > 0 ? queryParts.join('?') : undefined,
+  };
+}
+
+/**
+ * Normalize Next.js private internals to user-facing directories
+ */
+function normalizeInternalPath(resourcePath: string): string {
+  let normalized = resourcePath.replace(/\\/g, '/');
+
+  normalized = normalized.replace(/^\.\/+/, '').replace(/^\/+/, '');
+  normalized = normalized.replace(/^private-next-pages\//, 'pages/');
+  normalized = normalized.replace(/^private-next-app-dir\//, 'app/');
+  normalized = normalized.replace(/^private-next-middleware\//, 'middleware/');
+  normalized = normalized.replace(/^webpack-runtime\//, 'runtime/');
+  normalized = normalized.replace(/^__flight__\//, 'flight/');
+
+  if (normalized.startsWith('node_modules/.pnpm/')) {
+    const [, rest] = normalized.split('node_modules/.pnpm/');
+    if (rest) {
+      normalized = `node_modules/${rest.split('/node_modules/').pop() || rest}`;
+    }
+  }
+
+  return normalized;
+}
+
+/**
+ * Attempt to extract the original file path from a Next.js resource query.
+ * Handles parameters such as absolutePagePath, page, modules, appDir, etc.
+ */
+function extractPathFromQuery(query: string): string | undefined {
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(query);
+  } catch {
+    return undefined;
+  }
+
+  const lookupKeys = [
+    'absolutePagePath',
+    'absoluteAppPath',
+    'page',
+    'appDir',
+    'middleware',
+    'path',
+    'resource',
+    'modules',
+    'module',
+    'entry',
+  ];
+
+  for (const key of lookupKeys) {
+    const value = params.get(key);
+    if (!value) continue;
+
+    const decoded = decodeURIComponent(value);
+    if (hasModuleExtension(decoded)) {
+      return decoded;
+    }
+
+    // Some query params still contain loader syntax; recursively sanitize
+    const withoutLoader = stripWebpackLoaders(decoded);
+    if (hasModuleExtension(withoutLoader)) {
+      return withoutLoader;
+    }
+
+    // Handle comma-separated module lists (e.g., modules=a%2Fb.tsx,b%2Fc.ts)
+    if (decoded.includes(',')) {
+      const candidate = decoded
+        .split(',')
+        .map((item) => decodeURIComponent(item.trim()))
+        .find((item) => hasModuleExtension(item));
+      if (candidate) {
+        return stripWebpackLoaders(candidate);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Convert a module identifier to a base-directory-relative path
+ */
+function toAbsoluteModuleId(moduleId: string, baseDir: string): string {
+  if (!moduleId) {
+    return moduleId;
+  }
+
+  const normalizedBase = baseDir.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+  const cleaned = moduleId.replace(/\\/g, '/').replace(/^\.\/+/, '');
+
+  if (
+    cleaned.startsWith(`${normalizedBase}/`) ||
+    cleaned.startsWith('node_modules/') ||
+    cleaned.startsWith('virtual:') ||
+    cleaned.startsWith('webpack/')
+  ) {
+    return cleaned;
+  }
+
+  const withoutLeadingSlash = cleaned.replace(/^\/+/, '');
+  if (withoutLeadingSlash.length === 0) {
+    return normalizedBase;
+  }
+
+  return `${normalizedBase}/${withoutLeadingSlash}`;
+}

--- a/src/lib/server/plugins/nextjs/index.ts
+++ b/src/lib/server/plugins/nextjs/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Next.js bundle analysis plugin exports
+ */
+
+export {
+  NextJsBundleAnalysisPlugin,
+  nextJsBundleAnalysisPlugin,
+  withNextBundleAnalysis,
+} from './plugin.js';
+export type {
+  NextJsPluginOptions,
+  WithNextBundleAnalysisOptions,
+  NextConfig,
+  NextWebpackBuildContext,
+} from './plugin.js';
+
+export { NextJsAdapter, sanitizeModuleIdentifier } from './adapter.js';
+export type { NextJsAdapterOptions, NextJsBuildTarget, NextJsRuntime } from './adapter.js';

--- a/src/lib/server/plugins/nextjs/plugin.spec.ts
+++ b/src/lib/server/plugins/nextjs/plugin.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for Next.js bundle analysis plugin
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Compiler, Stats, Configuration } from 'webpack';
+import {
+  NextJsBundleAnalysisPlugin,
+  nextJsBundleAnalysisPlugin,
+  withNextBundleAnalysis,
+  type NextWebpackBuildContext,
+} from './plugin.js';
+import type { NextJsPluginOptions } from './plugin.js';
+
+// Mock ingestion to avoid touching the database layer
+vi.mock('../../ingestion/index.js', () => ({
+  ingestBundle: vi.fn().mockResolvedValue({
+    analysisRunId: 42,
+    bundlesWritten: 2,
+    modulesWritten: 10,
+    chunksWritten: 4,
+    statistics: {
+      totalBundles: 2,
+      totalModules: 10,
+      totalChunks: 4,
+    },
+  }),
+}));
+
+describe('NextJsBundleAnalysisPlugin', () => {
+  const baseOptions: NextJsPluginOptions = {
+    projectName: 'test-next-app',
+    buildTarget: 'client',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should construct via factory and register webpack hook', () => {
+    const plugin = nextJsBundleAnalysisPlugin(baseOptions);
+    expect(plugin).toBeInstanceOf(NextJsBundleAnalysisPlugin);
+
+    const compilerHooks = {
+      done: {
+        tapAsync: vi.fn(),
+      },
+    };
+
+    const mockCompiler = {
+      hooks: compilerHooks,
+      options: {
+        mode: 'production',
+        output: {
+          path: '/project/.next',
+        },
+      },
+    } as unknown as Compiler;
+
+    plugin.apply(mockCompiler);
+
+    expect(compilerHooks.done.tapAsync).toHaveBeenCalledWith(
+      'nextjs-bundle-analysis:client',
+      expect.any(Function),
+    );
+  });
+
+  it('should skip processing when productionOnly is true and mode is development', () => {
+    const plugin = nextJsBundleAnalysisPlugin({
+      ...baseOptions,
+      productionOnly: true,
+    });
+
+    const doneCallback = vi.fn();
+    const compilerHooks = {
+      done: {
+        tapAsync: vi.fn((_name, callback) => {
+          const mockStats = {
+            toJson: vi.fn().mockReturnValue({}),
+            compilation: {},
+          } as unknown as Stats;
+          callback(mockStats, doneCallback);
+        }),
+      },
+    };
+
+    const mockCompiler = {
+      hooks: compilerHooks,
+      options: {
+        mode: 'development',
+        output: { path: '/project/.next' },
+      },
+    } as unknown as Compiler;
+
+    plugin.apply(mockCompiler);
+
+    expect(compilerHooks.done.tapAsync).toHaveBeenCalled();
+    expect(doneCallback).toHaveBeenCalled();
+  });
+});
+
+describe('withNextBundleAnalysis', () => {
+  const baseOptions: NextJsPluginOptions = {
+    projectName: 'test-next-app',
+    buildTarget: 'client',
+  };
+
+  it('should inject plugin for client builds by default', () => {
+    const wrapped = withNextBundleAnalysis({}, { projectName: baseOptions.projectName });
+
+    const webpackConfig: Configuration = { plugins: [] };
+    const context: NextWebpackBuildContext = {
+      dir: '/project',
+      dev: false,
+      isServer: false,
+      config: {},
+      webpack: {} as NextWebpackBuildContext['webpack'],
+    };
+
+    const result = wrapped.webpack!(webpackConfig, context);
+    const resultConfig = result ?? webpackConfig;
+
+    expect(resultConfig.plugins).toHaveLength(1);
+    expect(resultConfig.plugins?.[0]).toBeInstanceOf(NextJsBundleAnalysisPlugin);
+  });
+
+  it('should honor analyzeServer flag', () => {
+    const wrapped = withNextBundleAnalysis(
+      {},
+      {
+        projectName: baseOptions.projectName,
+        analyzeClient: false,
+        analyzeServer: true,
+      },
+    );
+
+    const webpackConfig: Configuration = { plugins: [] };
+    const context: NextWebpackBuildContext = {
+      dir: '/project',
+      dev: false,
+      isServer: true,
+      config: {},
+      webpack: {} as NextWebpackBuildContext['webpack'],
+    };
+
+    const result = wrapped.webpack!(webpackConfig, context);
+    const resultConfig = result ?? webpackConfig;
+
+    expect(resultConfig.plugins).toHaveLength(1);
+    expect(resultConfig.plugins?.[0]).toBeInstanceOf(NextJsBundleAnalysisPlugin);
+  });
+});

--- a/src/lib/server/plugins/nextjs/plugin.ts
+++ b/src/lib/server/plugins/nextjs/plugin.ts
@@ -1,0 +1,278 @@
+/**
+ * Next.js webpack plugin for bundle analysis
+ * Wraps the webpack adapter with Next-specific configuration helpers
+ */
+
+import { resolve } from 'node:path';
+import type { Configuration, Compiler, Stats } from 'webpack';
+import type { BundlerPluginOptions, PluginConfig } from '../types.js';
+import type { BundleIngestionInput } from '../../ingestion/index.js';
+import { ingestBundle } from '../../ingestion/index.js';
+import {
+  NextJsAdapter,
+  type NextJsAdapterOptions,
+  type NextJsBuildTarget,
+  type NextJsRuntime,
+} from './adapter.js';
+
+/**
+ * Options for configuring the Next.js bundle analysis plugin.
+ * Extends the base bundler options with Next-specific fields.
+ */
+export interface NextJsPluginOptions extends BundlerPluginOptions {
+  /** Automatically ingest bundles after extraction */
+  autoIngest?: boolean;
+  /** Optional override for build output directory */
+  buildOutputDir?: string;
+  /** Only run plugin during production builds */
+  productionOnly?: boolean;
+  /** Next.js build target handled by this plugin instance */
+  buildTarget: NextJsBuildTarget;
+  /** Execution runtime */
+  runtime?: NextJsRuntime;
+  /** Next.js dist directory (defaults to .next) */
+  distDir?: string;
+}
+
+/**
+ * Options for wrapping Next.js config
+ */
+export interface WithNextBundleAnalysisOptions extends Omit<NextJsPluginOptions, 'buildTarget'> {
+  analyzeClient?: boolean;
+  analyzeServer?: boolean;
+  analyzeEdge?: boolean;
+  analyzeMiddleware?: boolean;
+}
+
+/**
+ * Partial Next.js config interface (avoids direct dependency on next package)
+ */
+export interface NextConfig extends Record<string, unknown> {
+  distDir?: string;
+  webpack?: (config: Configuration, context: NextWebpackBuildContext) => Configuration | void;
+}
+
+/**
+ * Shape of the build context passed by Next.js to the webpack override
+ */
+export interface NextWebpackBuildContext {
+  dir: string;
+  dev: boolean;
+  isServer: boolean;
+  nextRuntime?: NextJsRuntime;
+  config: NextConfig;
+  webpack: typeof import('webpack');
+  [key: string]: unknown;
+}
+
+/**
+ * Webpack plugin class for Next.js bundle analysis
+ */
+export class NextJsBundleAnalysisPlugin {
+  private options: NextJsPluginOptions;
+  private config?: PluginConfig;
+  private rootDir: string;
+
+  constructor(options: NextJsPluginOptions, config?: PluginConfig) {
+    this.options = options;
+    this.config = config;
+    this.rootDir = process.cwd();
+  }
+
+  /**
+   * Apply the plugin to a webpack compiler instance
+   */
+  apply(compiler: Compiler): void {
+    const pluginName = `nextjs-bundle-analysis:${this.options.buildTarget}`;
+
+    compiler.hooks.done.tapAsync(pluginName, async (stats: Stats, callback: () => void) => {
+      if (this.options.productionOnly && compiler.options.mode !== 'production') {
+        callback();
+        return;
+      }
+
+      try {
+        const outputPath =
+          this.options.buildOutputDir ||
+          compiler.options.output?.path ||
+          resolve(this.rootDir, this.options.distDir ?? '.next');
+
+        const adapterOptions: NextJsAdapterOptions = {
+          ...this.options,
+          buildTarget: this.options.buildTarget,
+          runtime:
+            this.options.runtime ??
+            (this.options.buildTarget === 'edge' || this.options.buildTarget === 'middleware'
+              ? 'edge'
+              : 'nodejs'),
+        };
+
+        const adapter = new NextJsAdapter(this.rootDir, adapterOptions, this.config);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const compilation: any =
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (stats as any).compilation || (compiler as any).compilation || compiler.hooks.compilation;
+
+        const extractionResult = adapter.extract({
+          stats,
+          compilation,
+          outputPath,
+          buildTarget: this.options.buildTarget,
+          runtime: adapterOptions.runtime,
+        });
+
+        if (extractionResult.warnings.length > 0) {
+          console.warn(
+            `[Next.js Bundle Analysis][${this.options.buildTarget}] Warnings:`,
+            extractionResult.warnings,
+          );
+        }
+
+        if (extractionResult.errors.length > 0) {
+          console.error(
+            `[Next.js Bundle Analysis][${this.options.buildTarget}] Errors:`,
+            extractionResult.errors,
+          );
+        }
+
+        if (this.options.autoIngest !== false) {
+          const ingestionInput: BundleIngestionInput = {
+            bundles: extractionResult.bundles,
+            modules: extractionResult.modules,
+            chunks: extractionResult.chunks,
+            options: extractionResult.options,
+          };
+
+          try {
+            const result = await ingestBundle(ingestionInput);
+            console.log(
+              `[Next.js Bundle Analysis][${this.options.buildTarget}] Ingested ${extractionResult.bundles.length} bundles, ` +
+                `${extractionResult.modules.length} modules, ${extractionResult.chunks.length} chunks. ` +
+                `Analysis run ID: ${result.analysisRunId}`,
+            );
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            console.error(
+              `[Next.js Bundle Analysis][${this.options.buildTarget}] Failed to ingest bundles:`,
+              errorMessage,
+            );
+            if (this.config?.debug) {
+              console.error('Full error details:', error);
+            }
+          }
+        }
+
+        callback();
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[Next.js Bundle Analysis][${this.options.buildTarget}] Failed to analyze bundle:`,
+          errorMessage,
+        );
+        if (this.config?.debug) {
+          console.error('Full error details:', error);
+        }
+        callback();
+      }
+    });
+  }
+}
+
+/**
+ * Factory function to create a Next.js bundle analysis plugin
+ */
+export function nextJsBundleAnalysisPlugin(
+  options: NextJsPluginOptions,
+  config?: PluginConfig,
+): NextJsBundleAnalysisPlugin {
+  if (!options.buildTarget) {
+    throw new Error(
+      'nextJsBundleAnalysisPlugin requires a buildTarget (client, server, edge, or middleware)',
+    );
+  }
+
+  return new NextJsBundleAnalysisPlugin(options, config);
+}
+
+/**
+ * Convenience helper to wrap a Next.js config and inject the plugin automatically
+ */
+export function withNextBundleAnalysis(
+  nextConfig: NextConfig = {},
+  options: WithNextBundleAnalysisOptions,
+  pluginConfig?: PluginConfig,
+): NextConfig {
+  const {
+    analyzeClient = true,
+    analyzeServer = true,
+    analyzeEdge = true,
+    analyzeMiddleware = true,
+    distDir,
+    ...pluginOptions
+  } = options;
+
+  const originalWebpack = nextConfig.webpack?.bind(nextConfig);
+
+  return {
+    ...nextConfig,
+    webpack: (config: Configuration, context: NextWebpackBuildContext) => {
+      const resolvedConfig = originalWebpack ? originalWebpack(config, context) || config : config;
+      resolvedConfig.plugins = resolvedConfig.plugins || [];
+
+      const target = resolveBuildTarget(context);
+      const shouldAnalyze =
+        (target === 'client' && analyzeClient) ||
+        (target === 'server' && analyzeServer) ||
+        (target === 'edge' && analyzeEdge) ||
+        (target === 'middleware' && analyzeMiddleware);
+
+      if (!shouldAnalyze) {
+        return resolvedConfig;
+      }
+
+      const resolvedDistDir = distDir ?? (context.config?.distDir as string | undefined) ?? '.next';
+
+      const plugin = nextJsBundleAnalysisPlugin(
+        {
+          ...pluginOptions,
+          buildTarget: target,
+          runtime:
+            pluginOptions.runtime ??
+            (target === 'edge' || target === 'middleware' ? 'edge' : 'nodejs'),
+          buildOutputDir:
+            pluginOptions.buildOutputDir ??
+            resolvedConfig.output?.path ??
+            resolve(context.dir, resolvedDistDir),
+          distDir: resolvedDistDir,
+        },
+        pluginConfig,
+      );
+
+      resolvedConfig.plugins.push(plugin);
+      return resolvedConfig;
+    },
+  };
+}
+
+/**
+ * Heuristic to determine the Next.js build target from build context
+ */
+function resolveBuildTarget(context: NextWebpackBuildContext): NextJsBuildTarget {
+  if (context.isServer) {
+    if (context.nextRuntime === 'edge') {
+      return 'edge';
+    }
+    const middleware = Boolean(context.middleware || context.page === '_middleware');
+    if (middleware) {
+      return 'middleware';
+    }
+    return 'server';
+  }
+
+  if (context.nextRuntime === 'edge') {
+    return 'middleware';
+  }
+
+  return 'client';
+}


### PR DESCRIPTION
## Summary
- add Next.js adapter built on the webpack plugin with Next-specific normalization
- expose Next.js webpack helper to attach the plugin automatically and document usage
- extend ingestion types to cover nextjs runs and add comprehensive unit tests

## Testing
- pnpm lint
- pnpm test

Closes #24