### PR TITLE
refactor: Align root landing page with brand identity

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,58 +6,90 @@
   }
 </script>
 
-<div class="landing-page">
+<div class="min-h-screen bg-gray-50 dark:bg-gray-900">
   <!-- Hero Section -->
-  <section class="hero">
-    <div class="hero-content">
-      <h1 class="hero-title">Smappy</h1>
-      <p class="hero-tagline">Visualize, analyze, and optimize your JavaScript bundles</p>
-      <p class="hero-description">
+  <section
+    class="flex min-h-[70vh] items-center justify-center bg-gradient-to-br from-primary-600 to-primary-700 px-6 py-16"
+  >
+    <div class="max-w-3xl text-center">
+      <img
+        src="/logo.svg"
+        alt="Smappy - Bundle Analyzer"
+        class="mx-auto mb-8 h-20 brightness-0 invert"
+      />
+      <p class="text-primary-100 mb-6 text-2xl font-medium sm:text-3xl">
+        Visualize, analyze, and optimize your JavaScript bundles
+      </p>
+      <p class="text-primary-50 mb-8 text-lg leading-relaxed">
         Track bundle sizes over time, detect circular dependencies, and get AI-powered optimization
         suggestions for your Vite, Next.js, Webpack, and other JavaScript projects.
       </p>
-      <div class="hero-actions">
-        <button class="btn-primary" onclick={navigateToDashboard}>View Dashboard</button>
-        <a href="#quick-start" class="btn-secondary">Get Started</a>
+      <div class="flex flex-wrap items-center justify-center gap-4">
+        <button
+          class="rounded-lg bg-white px-8 py-3 text-lg font-semibold text-primary-600 shadow-lg transition-all hover:-translate-y-0.5 hover:shadow-xl"
+          onclick={navigateToDashboard}
+        >
+          View Dashboard
+        </button>
+        <a
+          href="#quick-start"
+          class="rounded-lg border-2 border-white bg-transparent px-8 py-3 text-lg font-semibold text-white transition-all hover:bg-white/10"
+        >
+          Get Started
+        </a>
       </div>
     </div>
   </section>
 
   <!-- Features Section -->
-  <section class="features">
-    <h2 class="section-title">Key Features</h2>
-    <div class="features-grid">
-      <div class="feature-card">
-        <div class="feature-icon">📊</div>
-        <h3 class="feature-title">Bundle Size Tracking</h3>
-        <p class="feature-description">
+  <section class="mx-auto max-w-6xl px-6 py-20">
+    <h2 class="mb-12 text-center text-4xl font-bold text-gray-900 dark:text-white">Key Features</h2>
+    <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div class="mb-4 text-5xl">📊</div>
+        <h3 class="mb-3 text-xl font-semibold text-gray-900 dark:text-white">
+          Bundle Size Tracking
+        </h3>
+        <p class="leading-relaxed text-gray-600 dark:text-gray-400">
           Monitor your bundle sizes over time and catch size regressions before they reach
           production.
         </p>
       </div>
 
-      <div class="feature-card">
-        <div class="feature-icon">🔍</div>
-        <h3 class="feature-title">Dependency Graph</h3>
-        <p class="feature-description">
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div class="mb-4 text-5xl">🔍</div>
+        <h3 class="mb-3 text-xl font-semibold text-gray-900 dark:text-white">Dependency Graph</h3>
+        <p class="leading-relaxed text-gray-600 dark:text-gray-400">
           Visualize module dependencies and automatically detect circular dependencies that can
           cause issues.
         </p>
       </div>
 
-      <div class="feature-card">
-        <div class="feature-icon">🤖</div>
-        <h3 class="feature-title">AI-Powered Suggestions</h3>
-        <p class="feature-description">
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div class="mb-4 text-5xl">🤖</div>
+        <h3 class="mb-3 text-xl font-semibold text-gray-900 dark:text-white">
+          AI-Powered Suggestions
+        </h3>
+        <p class="leading-relaxed text-gray-600 dark:text-gray-400">
           Get intelligent optimization recommendations to reduce bundle size and improve
           performance.
         </p>
       </div>
 
-      <div class="feature-card">
-        <div class="feature-icon">⚡</div>
-        <h3 class="feature-title">Multi-Bundler Support</h3>
-        <p class="feature-description">
+      <div
+        class="rounded-xl border border-gray-200 bg-white p-8 shadow-sm transition-shadow hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div class="mb-4 text-5xl">⚡</div>
+        <h3 class="mb-3 text-xl font-semibold text-gray-900 dark:text-white">
+          Multi-Bundler Support
+        </h3>
+        <p class="leading-relaxed text-gray-600 dark:text-gray-400">
           Works seamlessly with Vite, Next.js, Webpack, Rollup, and other popular JavaScript
           bundlers.
         </p>
@@ -66,17 +98,30 @@
   </section>
 
   <!-- Quick Start Section -->
-  <section id="quick-start" class="quick-start">
-    <h2 class="section-title">Quick Start</h2>
-    <div class="quick-start-content">
-      <div class="installation-step">
-        <h3 class="step-title">1. Install the plugin</h3>
-        <pre class="code-block"><code>npm install smappy-plugin --save-dev</code></pre>
+  <section id="quick-start" class="mx-auto max-w-4xl px-6 py-20">
+    <h2 class="mb-12 text-center text-4xl font-bold text-gray-900 dark:text-white">Quick Start</h2>
+    <div class="flex flex-col gap-8">
+      <div
+        class="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          1. Install the plugin
+        </h3>
+        <pre
+          class="overflow-x-auto rounded-md bg-gray-900 p-4 font-mono text-sm dark:bg-gray-950"><code
+            class="text-gray-200">npm install smappy-plugin --save-dev</code
+          ></pre>
       </div>
 
-      <div class="installation-step">
-        <h3 class="step-title">2. Configure your bundler</h3>
-        <pre class="code-block"><code
+      <div
+        class="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          2. Configure your bundler
+        </h3>
+        <pre
+          class="overflow-x-auto rounded-md bg-gray-900 p-4 font-mono text-sm dark:bg-gray-950"><code
+            class="text-gray-200"
             >{`// vite.config.js
 import { smappyPlugin } from 'smappy-plugin';
 
@@ -86,369 +131,60 @@ export default {
           ></pre>
       </div>
 
-      <div class="installation-step">
-        <h3 class="step-title">3. Run your build</h3>
-        <pre class="code-block"><code>npm run build</code></pre>
+      <div
+        class="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">3. Run your build</h3>
+        <pre
+          class="overflow-x-auto rounded-md bg-gray-900 p-4 font-mono text-sm dark:bg-gray-950"><code
+            class="text-gray-200">npm run build</code
+          ></pre>
       </div>
 
-      <div class="installation-step">
-        <h3 class="step-title">4. View the dashboard</h3>
-        <p class="step-description">
-          Visit <a href="/dashboard" class="text-link">the dashboard</a> to see your bundle analysis
+      <div
+        class="rounded-lg border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800"
+      >
+        <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          4. View the dashboard
+        </h3>
+        <p class="leading-relaxed text-gray-600 dark:text-gray-400">
+          Visit <a
+            href="/dashboard"
+            class="font-medium text-primary-600 underline hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+            >the dashboard</a
+          > to see your bundle analysis
         </p>
       </div>
     </div>
   </section>
 
   <!-- Footer -->
-  <footer class="footer">
-    <div class="footer-content">
-      <div class="footer-links">
+  <footer
+    class="border-t border-gray-200 bg-white px-6 py-12 dark:border-gray-700 dark:bg-gray-800"
+  >
+    <div class="mx-auto max-w-6xl text-center">
+      <div class="mb-4 flex flex-wrap items-center justify-center gap-8">
         <a
           href="https://github.com/hybrist/smappy"
           target="_blank"
           rel="noopener noreferrer"
-          class="footer-link">GitHub</a
+          class="font-medium text-gray-600 transition-colors hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
+          >GitHub</a
         >
-        <a href="/dashboard" class="footer-link">Dashboard</a>
+        <a
+          href="/dashboard"
+          class="font-medium text-gray-600 transition-colors hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
+          >Dashboard</a
+        >
         <a
           href="https://github.com/hybrist/smappy/blob/main/docs/bundler-integration/README.md"
           target="_blank"
           rel="noopener noreferrer"
-          class="footer-link">Documentation</a
+          class="font-medium text-gray-600 transition-colors hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-400"
+          >Documentation</a
         >
       </div>
-      <p class="footer-version">Smappy v0.0.1</p>
+      <p class="text-sm text-gray-500 dark:text-gray-600">Smappy v0.0.1</p>
     </div>
   </footer>
 </div>
-
-<style>
-  .landing-page {
-    min-height: 100vh;
-    background-color: #f9fafb;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .landing-page {
-      background-color: #111827;
-    }
-  }
-
-  /* Hero Section */
-  .hero {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 70vh;
-    padding: 4rem 1.5rem;
-    background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  }
-
-  .hero-content {
-    max-width: 48rem;
-    text-align: center;
-  }
-
-  .hero-title {
-    margin-bottom: 1rem;
-    font-size: 3.75rem;
-    font-weight: 800;
-    color: #ffffff;
-    letter-spacing: -0.025em;
-  }
-
-  @media (max-width: 640px) {
-    .hero-title {
-      font-size: 2.5rem;
-    }
-  }
-
-  .hero-tagline {
-    margin-bottom: 1.5rem;
-    font-size: 1.5rem;
-    font-weight: 500;
-    color: #dbeafe;
-  }
-
-  @media (max-width: 640px) {
-    .hero-tagline {
-      font-size: 1.25rem;
-    }
-  }
-
-  .hero-description {
-    margin-bottom: 2rem;
-    font-size: 1.125rem;
-    line-height: 1.75;
-    color: #bfdbfe;
-  }
-
-  .hero-actions {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-
-  .btn-primary {
-    cursor: pointer;
-    border-radius: 0.5rem;
-    background-color: #ffffff;
-    padding: 0.75rem 2rem;
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: #2563eb;
-    border: none;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
-    transition: all 0.2s;
-  }
-
-  .btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.2);
-  }
-
-  .btn-secondary {
-    cursor: pointer;
-    border-radius: 0.5rem;
-    border: 2px solid #ffffff;
-    background-color: transparent;
-    padding: 0.75rem 2rem;
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: #ffffff;
-    text-decoration: none;
-    transition: all 0.2s;
-  }
-
-  .btn-secondary:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-  }
-
-  /* Features Section */
-  .features {
-    padding: 5rem 1.5rem;
-    max-width: 72rem;
-    margin: 0 auto;
-  }
-
-  .section-title {
-    margin-bottom: 3rem;
-    text-align: center;
-    font-size: 2.25rem;
-    font-weight: 700;
-    color: #111827;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .section-title {
-      color: #ffffff;
-    }
-  }
-
-  .features-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
-
-  @media (min-width: 768px) {
-    .features-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-  }
-
-  .feature-card {
-    border-radius: 0.75rem;
-    border: 1px solid #e5e7eb;
-    background-color: #ffffff;
-    padding: 2rem;
-    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
-    transition: box-shadow 0.2s;
-  }
-
-  .feature-card:hover {
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .feature-card {
-      border-color: #374151;
-      background-color: #1f2937;
-    }
-  }
-
-  .feature-icon {
-    margin-bottom: 1rem;
-    font-size: 2.5rem;
-  }
-
-  .feature-title {
-    margin-bottom: 0.75rem;
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: #111827;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .feature-title {
-      color: #ffffff;
-    }
-  }
-
-  .feature-description {
-    line-height: 1.625;
-    color: #4b5563;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .feature-description {
-      color: #9ca3af;
-    }
-  }
-
-  /* Quick Start Section */
-  .quick-start {
-    padding: 5rem 1.5rem;
-    max-width: 56rem;
-    margin: 0 auto;
-  }
-
-  .quick-start-content {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-  }
-
-  .installation-step {
-    border-radius: 0.5rem;
-    border: 1px solid #e5e7eb;
-    background-color: #ffffff;
-    padding: 1.5rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .installation-step {
-      border-color: #374151;
-      background-color: #1f2937;
-    }
-  }
-
-  .step-title {
-    margin-bottom: 1rem;
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: #111827;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .step-title {
-      color: #ffffff;
-    }
-  }
-
-  .step-description {
-    line-height: 1.625;
-    color: #4b5563;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .step-description {
-      color: #9ca3af;
-    }
-  }
-
-  .code-block {
-    border-radius: 0.375rem;
-    background-color: #111827;
-    padding: 1rem;
-    overflow-x: auto;
-    font-family: 'Courier New', monospace;
-    font-size: 0.875rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .code-block {
-      background-color: #030712;
-    }
-  }
-
-  .code-block code {
-    color: #e5e7eb;
-  }
-
-  .text-link {
-    color: #2563eb;
-    text-decoration: underline;
-    font-weight: 500;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .text-link {
-      color: #60a5fa;
-    }
-  }
-
-  /* Footer */
-  .footer {
-    border-top: 1px solid #e5e7eb;
-    background-color: #ffffff;
-    padding: 3rem 1.5rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .footer {
-      border-top-color: #374151;
-      background-color: #1f2937;
-    }
-  }
-
-  .footer-content {
-    max-width: 72rem;
-    margin: 0 auto;
-    text-align: center;
-  }
-
-  .footer-links {
-    display: flex;
-    gap: 2rem;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 1rem;
-    flex-wrap: wrap;
-  }
-
-  .footer-link {
-    color: #4b5563;
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s;
-  }
-
-  .footer-link:hover {
-    color: #2563eb;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .footer-link {
-      color: #9ca3af;
-    }
-
-    .footer-link:hover {
-      color: #60a5fa;
-    }
-  }
-
-  .footer-version {
-    color: #9ca3af;
-    font-size: 0.875rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .footer-version {
-      color: #6b7280;
-    }
-  }
-</style>

--- a/src/routes/page.svelte.spec.ts
+++ b/src/routes/page.svelte.spec.ts
@@ -4,12 +4,11 @@ import { render } from 'vitest-browser-svelte';
 import Page from './+page.svelte';
 
 describe('/+page.svelte', () => {
-  it('should render hero title', async () => {
+  it('should render Smappy logo', async () => {
     render(Page);
 
-    const heading = page.getByRole('heading', { level: 1 });
-    await expect.element(heading).toBeInTheDocument();
-    await expect.element(heading).toHaveTextContent('Smappy');
+    const logo = page.getByAltText('Smappy - Bundle Analyzer');
+    await expect.element(logo).toBeInTheDocument();
   });
 
   it('should render tagline', async () => {


### PR DESCRIPTION
## Summary

Updates the root landing page (`/`) to match the new crocodile brand identity and Tailwind-first approach implemented in #107.

## Changes

### Brand Alignment
- Added Smappy crocodile logo to hero section
- Replaced blue gradient with emerald green (primary-600 to primary-700)
- Updated all link colors from blue to emerald green brand colors
- Footer links now use primary brand colors on hover

### Code Quality
- Converted ALL custom CSS to Tailwind utilities
- Removed 275 lines of custom CSS (~60% reduction: 455 → 180 lines)
- Consistent with dashboard pages' Tailwind-first approach

### Visual Updates
- Hero: Emerald green gradient background with white logo
- Features: Consistent card styling with brand colors
- Quick Start: Updated code blocks and link colors
- Footer: Brand color hover states on links

## Before vs After

**Before:**
- Custom CSS classes (330+ lines)
- Blue gradient hero
- Plain "Smappy" text (no logo)
- Blue link colors (#2563eb)

**After:**
- Pure Tailwind utilities
- Emerald green gradient hero
- Crocodile logo with icon
- Emerald green brand colors (primary-600/400)

## Testing
- Type checking: 0 errors
- Code formatted with Prettier
- Responsive design maintained
- Dark mode support verified

Related to #91

Co-Authored-By: Claude <noreply@anthropic.com>