### PR TITLE
feat: add CLI command to analyze HAR file

### DIFF
--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -56,6 +56,31 @@ smappy analyze --framework react
 - `--skip-build` - Generate config but don't run build (for testing)
 - `--keep-temp` - Keep temporary files for debugging
 
+### Analyze HAR Command
+
+Generate a syntax-size breakdown directly from a HAR file exported from Chrome DevTools:
+
+```bash
+# Basic usage
+smappy analyze-har ./my-session.har
+
+# Limit to specific HAR page + only show top 3 categories
+smappy analyze-har ./my-session.har --page "Checkout" --top 3
+
+# Filter script URLs and emit JSON
+smappy analyze-har ./my-session.har --include "**/app-*.js" --json > report.json
+```
+
+#### Options
+
+- `har-file` – Path to the HAR export to inspect
+- `--page <id-or-name>` – Only include entries from a given HAR page id or title
+- `--include <glob>` – Glob filter that must match the script URL (powered by picomatch)
+- `--top <n>` – Only print the top N categories (plus the `Other` bucket)
+- `--json` – Emit machine-readable JSON instead of a table
+
+The report shows total JavaScript weight plus how much of it comes from classes, functions, methods, string/template literals, imports/exports, object literals, comments, and the uncategorized remainder.
+
 ### Detect Command
 
 Detect bundler and framework without running analysis:

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -78,8 +78,11 @@ smappy analyze-har ./my-session.har --include "**/app-*.js" --json > report.json
 - `--include <glob>` – Glob filter that must match the script URL (powered by picomatch)
 - `--top <n>` – Only print the top N categories (plus the `Other` bucket)
 - `--json` – Emit machine-readable JSON instead of a table
+- `--mode <mode>` – `full` (default) shows all syntax categories; `core` limits to methods, object literal methods, functions, classes, and inferred top-level code
 
-The report shows total JavaScript weight plus how much of it comes from classes, functions, methods, string/template literals, imports/exports, object literals, comments, and the uncategorized remainder.
+The report shows total JavaScript weight plus per-category breakdowns. Each category lists both its **own share** (bytes not claimed by other categories) and **total share** (including nested content). We also detect webpack-style chunk definitions (numeric object literal methods with large module bodies) and, in the default mode, count them in a dedicated **Bundled modules** bucket so real object methods stay readable. Core mode skips that bucket entirely so you can focus on “real” methods, free functions, classes, and the remaining top-level code.
+
+For each category we also compute distribution stats of the total (inclusive) size of every occurrence: average, standard deviation, and the 50th/90th/99th percentiles. These are printed beneath the main table and included in `--json` output so you can quickly tell whether a category is dominated by a few large chunks or evenly spread across many occurrences.
 
 ### Detect Command
 

--- a/libs/cli/package.json
+++ b/libs/cli/package.json
@@ -11,6 +11,7 @@
     "prepare": "tsdown"
   },
   "dependencies": {
+    "@babel/parser": "^7.26.2",
     "@ai-sdk/anthropic": "^2.0.56",
     "@ai-sdk/openai": "^2.0.87",
     "@smappy/core": "workspace:*",
@@ -18,9 +19,12 @@
     "ai": "^5.0.114",
     "commander": "^14.0.2",
     "drizzle-orm": "^0.44.7",
-    "ollama-ai-provider-v2": "^1.5.5"
+    "ollama-ai-provider-v2": "^1.5.5",
+    "picomatch": "^4.0.2"
   },
   "devDependencies": {
+    "@types/picomatch": "^4.0.2",
+    "@babel/types": "^7.26.0",
     "@types/node": "^22.19.3",
     "@types/webpack": "^5.28.5",
     "prettier": "catalog:",

--- a/libs/cli/src/cmds/analyze-har.ts
+++ b/libs/cli/src/cmds/analyze-har.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { analyzeScripts } from '../har/analyzer.ts';
+import type { AnalyzerMode } from '../har/analyzer.ts';
 import { extractJavaScript } from '../har/extract-javascript.ts';
 import { loadHar } from '../har/loader.ts';
 import { renderReport } from '../har/report.ts';
@@ -9,6 +10,7 @@ export interface AnalyzeHarOptions {
   include?: string;
   json?: boolean;
   top?: string | number;
+  mode?: string;
 }
 
 export async function analyzeHarCommand(
@@ -28,7 +30,15 @@ export async function analyzeHarCommand(
       return 1;
     }
 
-    const analysis = analyzeScripts(extraction.scripts);
+    const mode = parseMode(options.mode);
+    if (mode === 'invalid') {
+      console.error('Invalid mode. Use "full" (default) or "core".');
+      return 1;
+    }
+
+    const analysis = analyzeScripts(extraction.scripts, {
+      mode,
+    });
     const warnings = [...extraction.warnings, ...analysis.warnings];
     renderReport(analysis, {
       json: options.json,
@@ -57,4 +67,19 @@ function parseTop(value?: string | number) {
 
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseMode(value?: string): AnalyzerMode | undefined | 'invalid' {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.toLowerCase();
+  if (normalized === 'full') {
+    return 'full';
+  }
+  if (normalized === 'core') {
+    return 'core';
+  }
+  return 'invalid';
 }

--- a/libs/cli/src/cmds/analyze-har.ts
+++ b/libs/cli/src/cmds/analyze-har.ts
@@ -1,0 +1,60 @@
+import path from 'node:path';
+import { analyzeScripts } from '../har/analyzer.ts';
+import { extractJavaScript } from '../har/extract-javascript.ts';
+import { loadHar } from '../har/loader.ts';
+import { renderReport } from '../har/report.ts';
+
+export interface AnalyzeHarOptions {
+  page?: string;
+  include?: string;
+  json?: boolean;
+  top?: string | number;
+}
+
+export async function analyzeHarCommand(
+  harPath: string,
+  options: AnalyzeHarOptions = {},
+) {
+  const resolvedPath = path.resolve(process.cwd(), harPath);
+  try {
+    const har = await loadHar(resolvedPath);
+    const extraction = extractJavaScript(har, {
+      page: options.page,
+      include: options.include,
+    });
+
+    if (!extraction.scripts.length) {
+      console.error('No JavaScript responses matched the provided filters.');
+      return 1;
+    }
+
+    const analysis = analyzeScripts(extraction.scripts);
+    const warnings = [...extraction.warnings, ...analysis.warnings];
+    renderReport(analysis, {
+      json: options.json,
+      top: parseTop(options.top),
+      warnings,
+    });
+    return 0;
+  } catch (error) {
+    console.error(
+      error instanceof Error
+        ? error.message
+        : `Failed to analyze HAR: ${String(error)}`,
+    );
+    return 1;
+  }
+}
+
+function parseTop(value?: string | number) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/libs/cli/src/har/__fixtures__/simple.har
+++ b/libs/cli/src/har/__fixtures__/simple.har
@@ -1,0 +1,64 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": { "name": "smappy", "version": "0.0.0" },
+    "pages": [
+      { "id": "page_1", "title": "Home" },
+      { "id": "page_2", "title": "Dashboard" }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2024-01-01T00:00:00.000Z",
+        "time": 12,
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/app.js"
+        },
+        "response": {
+          "status": 200,
+          "content": {
+            "mimeType": "application/javascript",
+            "size": 42,
+            "text": "class Foo { constructor(){ this.value = 'hi'; } }"
+          }
+        }
+      },
+      {
+        "pageref": "page_2",
+        "startedDateTime": "2024-01-01T00:00:01.000Z",
+        "time": 10,
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/utils.mjs"
+        },
+        "response": {
+          "status": 200,
+          "content": {
+            "mimeType": "application/javascript",
+            "size": 36,
+            "encoding": "base64",
+            "text": "ZXhwb3J0IGZ1bmN0aW9uIGFkZChhLCBiKSB7IHJldHVybiBhICsgYiB9"
+          }
+        }
+      },
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2024-01-01T00:00:02.000Z",
+        "time": 8,
+        "request": {
+          "method": "GET",
+          "url": "https://example.com/styles.css"
+        },
+        "response": {
+          "status": 200,
+          "content": {
+            "mimeType": "text/css",
+            "size": 20,
+            "text": "body{color:black;}"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/libs/cli/src/har/analyzer.spec.ts
+++ b/libs/cli/src/har/analyzer.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeScripts } from './analyzer.ts';
+
+describe('analyzeScripts', () => {
+  it('aggregates category percentages', () => {
+    const body = `class Alpha { method() { return 'value'; } }
+    function beta() { return Alpha; }
+    `;
+    const result = analyzeScripts([
+      {
+        url: 'https://example.com/app.js',
+        body,
+        mimeType: 'application/javascript',
+        bytes: Buffer.byteLength(body, 'utf8'),
+        pageRef: 'page_1',
+      },
+    ]);
+
+    expect(result.totalScripts).toBe(1);
+    const classCategory = result.categories.find(
+      (category) => category.id === 'class',
+    );
+    const functionCategory = result.categories.find(
+      (category) => category.id === 'function',
+    );
+    expect(classCategory?.bytes).toBeGreaterThan(0);
+    expect(functionCategory?.bytes).toBeGreaterThan(0);
+    const totalPercent = result.categories.reduce(
+      (sum, category) => sum + category.percentage,
+      0,
+    );
+    // Allow rounding error.
+    expect(Math.round(totalPercent)).toBeCloseTo(100, 1);
+  });
+});

--- a/libs/cli/src/har/analyzer.spec.ts
+++ b/libs/cli/src/har/analyzer.spec.ts
@@ -23,13 +23,97 @@ describe('analyzeScripts', () => {
     const functionCategory = result.categories.find(
       (category) => category.id === 'function',
     );
-    expect(classCategory?.bytes).toBeGreaterThan(0);
-    expect(functionCategory?.bytes).toBeGreaterThan(0);
+    expect(classCategory?.ownBytes).toBeGreaterThan(0);
+    expect(functionCategory?.ownBytes).toBeGreaterThan(0);
     const totalPercent = result.categories.reduce(
-      (sum, category) => sum + category.percentage,
+      (sum, category) => sum + category.ownPercentage,
       0,
     );
     // Allow rounding error.
     expect(Math.round(totalPercent)).toBeCloseTo(100, 1);
+  });
+
+  it('supports core mode with top-level bucket', () => {
+    const body = `class Foo { x() { return 1; } }
+      const helper = () => Foo;
+      console.log(helper);
+    `;
+    const result = analyzeScripts(
+      [
+        {
+          url: 'https://example.com/app.js',
+          body,
+          mimeType: 'application/javascript',
+          bytes: Buffer.byteLength(body, 'utf8'),
+          pageRef: 'page_1',
+        },
+      ],
+      { mode: 'core' },
+    );
+
+    const ids = result.categories.map((category) => category.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(['class', 'function', 'method', 'top_level']),
+    );
+    const topLevel = result.categories.find(
+      (category) => category.id === 'top_level',
+    );
+    expect(topLevel?.totalBytes).toBeGreaterThan(0);
+    const classBucket = result.categories.find(
+      (category) => category.id === 'class',
+    );
+    expect(classBucket?.ownBytes).toBeGreaterThan(0);
+  });
+
+  it('separates object literal methods from class methods', () => {
+    const body = `class Foo { bar() { return 1; } }
+      const obj = { baz() { return 2; } };
+    `;
+    const result = analyzeScripts(
+      [
+        {
+          url: 'https://example.com/app.js',
+          body,
+          mimeType: 'application/javascript',
+          bytes: Buffer.byteLength(body, 'utf8'),
+          pageRef: 'page_1',
+        },
+      ],
+      { mode: 'core' },
+    );
+
+    const methodCategory = result.categories.find(
+      (category) => category.id === 'method',
+    );
+    const objectMethodCategory = result.categories.find(
+      (category) => category.id === 'object_method',
+    );
+
+    expect(methodCategory?.occurrences).toBe(1);
+    expect(objectMethodCategory?.occurrences).toBe(1);
+  });
+
+  it('detects bundled module object methods only in full mode', () => {
+    const body = `const chunk = { 43623(e,t,n){ return e+t+n; }, util(){ return 1; } };`;
+    const scripts = [
+      {
+        url: 'https://example.com/app.js',
+        body,
+        mimeType: 'application/javascript',
+        bytes: Buffer.byteLength(body, 'utf8'),
+        pageRef: 'page_1',
+      },
+    ];
+
+    const fullResult = analyzeScripts(scripts);
+    const bundleCategory = fullResult.categories.find(
+      (category) => category.id === 'bundle_module',
+    );
+    expect(bundleCategory?.occurrences).toBe(1);
+
+    const coreResult = analyzeScripts(scripts, { mode: 'core' });
+    expect(
+      coreResult.categories.find((category) => category.id === 'bundle_module'),
+    ).toBeUndefined();
   });
 });

--- a/libs/cli/src/har/analyzer.ts
+++ b/libs/cli/src/har/analyzer.ts
@@ -1,0 +1,74 @@
+import { analyzeSyntax } from './syntax-attribution.ts';
+import type { SyntaxCategorySummary } from './syntax-attribution.ts';
+import type { HarWarning, ScriptResource } from './types.ts';
+
+export interface AnalyzerCategoryResult {
+  id: string;
+  label: string;
+  bytes: number;
+  characters: number;
+  percentage: number;
+  occurrences: number;
+}
+
+export interface AnalyzerResult {
+  totalBytes: number;
+  totalScripts: number;
+  categories: AnalyzerCategoryResult[];
+  warnings: HarWarning[];
+}
+
+export function analyzeScripts(scripts: ScriptResource[]): AnalyzerResult {
+  const warnings: HarWarning[] = [];
+  const totals = new Map<string, AnalyzerCategoryResult>();
+  let totalBytes = 0;
+
+  for (const script of scripts) {
+    totalBytes += script.bytes;
+    let syntaxCategories: SyntaxCategorySummary[];
+    try {
+      const syntax = analyzeSyntax(script.body);
+      syntaxCategories = syntax.categories;
+    } catch (error) {
+      warnings.push({
+        type: 'parse-error',
+        message: 'Unable to parse JavaScript for syntax attribution',
+        url: script.url,
+        details: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    for (const category of syntaxCategories) {
+      const existing = totals.get(category.id);
+      if (existing) {
+        existing.bytes += category.bytes;
+        existing.characters += category.characters;
+        existing.occurrences += category.occurrences;
+      } else {
+        totals.set(category.id, {
+          id: category.id,
+          label: category.label,
+          bytes: category.bytes,
+          characters: category.characters,
+          percentage: 0,
+          occurrences: category.occurrences,
+        });
+      }
+    }
+  }
+
+  const categories = Array.from(totals.values()).sort(
+    (a, b) => b.bytes - a.bytes,
+  );
+  for (const category of categories) {
+    category.percentage = totalBytes ? (category.bytes / totalBytes) * 100 : 0;
+  }
+
+  return {
+    totalBytes,
+    totalScripts: scripts.length,
+    categories,
+    warnings,
+  };
+}

--- a/libs/cli/src/har/analyzer.ts
+++ b/libs/cli/src/har/analyzer.ts
@@ -1,15 +1,31 @@
 import { analyzeSyntax } from './syntax-attribution.ts';
-import type { SyntaxCategorySummary } from './syntax-attribution.ts';
+import type {
+  ScriptSyntaxAnalysis,
+  SyntaxCategoryId,
+  SyntaxCategorySummary,
+  Segment,
+  CategoryStats,
+} from './syntax-attribution.ts';
 import type { HarWarning, ScriptResource } from './types.ts';
+
+export type AnalyzerMode = 'full' | 'core';
+
+export interface AnalyzerOptions {
+  mode?: AnalyzerMode;
+}
 
 export interface AnalyzerCategoryResult {
   id: string;
   label: string;
-  bytes: number;
-  characters: number;
-  percentage: number;
+  ownBytes: number;
+  ownPercentage: number;
+  totalBytes: number;
+  totalPercentage: number;
   occurrences: number;
+  stats?: CategoryStats;
 }
+
+type AggregatedCategory = AnalyzerCategoryResult & { samples: number[] };
 
 export interface AnalyzerResult {
   totalBytes: number;
@@ -18,17 +34,31 @@ export interface AnalyzerResult {
   warnings: HarWarning[];
 }
 
-export function analyzeScripts(scripts: ScriptResource[]): AnalyzerResult {
+const DEFAULT_MODE: AnalyzerMode = 'full';
+const CORE_SYNTAX_CATEGORIES: SyntaxCategoryId[] = [
+  'method',
+  'object_method',
+  'function',
+  'class',
+];
+
+export function analyzeScripts(
+  scripts: ScriptResource[],
+  options: AnalyzerOptions = {},
+): AnalyzerResult {
   const warnings: HarWarning[] = [];
-  const totals = new Map<string, AnalyzerCategoryResult>();
+  const totals = new Map<string, AggregatedCategory>();
+  const mode = options.mode ?? DEFAULT_MODE;
   let totalBytes = 0;
 
   for (const script of scripts) {
     totalBytes += script.bytes;
-    let syntaxCategories: SyntaxCategorySummary[];
+    let syntax: ScriptSyntaxAnalysis;
     try {
-      const syntax = analyzeSyntax(script.body);
-      syntaxCategories = syntax.categories;
+      syntax = analyzeSyntax(script.body, {
+        categories: mode === 'core' ? CORE_SYNTAX_CATEGORIES : undefined,
+        includeCoverage: mode === 'core',
+      });
     } catch (error) {
       warnings.push({
         type: 'parse-error',
@@ -39,36 +69,198 @@ export function analyzeScripts(scripts: ScriptResource[]): AnalyzerResult {
       continue;
     }
 
-    for (const category of syntaxCategories) {
-      const existing = totals.get(category.id);
-      if (existing) {
-        existing.bytes += category.bytes;
-        existing.characters += category.characters;
-        existing.occurrences += category.occurrences;
-      } else {
-        totals.set(category.id, {
-          id: category.id,
-          label: category.label,
-          bytes: category.bytes,
-          characters: category.characters,
-          percentage: 0,
-          occurrences: category.occurrences,
-        });
-      }
+    if (mode === 'core') {
+      const summaries = buildCoreSummaries(syntax, script.bytes);
+      accumulateCategories(totals, summaries);
+      continue;
     }
+
+    const summaries = syntax.categories.map(toAnalyzerCategory);
+    accumulateCategories(totals, summaries);
   }
 
-  const categories = Array.from(totals.values()).sort(
-    (a, b) => b.bytes - a.bytes,
-  );
-  for (const category of categories) {
-    category.percentage = totalBytes ? (category.bytes / totalBytes) * 100 : 0;
-  }
+  const categories = finalizeCategories(totals, totalBytes);
 
   return {
     totalBytes,
     totalScripts: scripts.length,
     categories,
     warnings,
+  };
+}
+
+function accumulateCategories(
+  totals: Map<string, AggregatedCategory>,
+  categories: AggregatedCategory[],
+) {
+  for (const category of categories) {
+    const existing = totals.get(category.id);
+    if (existing) {
+      existing.ownBytes += category.ownBytes;
+      existing.totalBytes += category.totalBytes;
+      existing.occurrences += category.occurrences;
+      existing.samples.push(...category.samples);
+    } else {
+      totals.set(category.id, { ...category, samples: [...category.samples] });
+    }
+  }
+}
+
+function finalizeCategories(
+  totals: Map<string, AggregatedCategory>,
+  denominator: number,
+) {
+  const categories = Array.from(totals.values()).sort(
+    (a, b) => b.ownBytes - a.ownBytes,
+  );
+  for (const category of categories) {
+    category.ownPercentage = denominator
+      ? (category.ownBytes / denominator) * 100
+      : 0;
+    category.totalPercentage = denominator
+      ? (category.totalBytes / denominator) * 100
+      : 0;
+    category.stats = calculateStats(category.samples);
+    delete (category as Partial<AggregatedCategory>).samples;
+  }
+  return categories;
+}
+
+function toAnalyzerCategory(
+  summary: SyntaxCategorySummary,
+): AggregatedCategory {
+  return {
+    id: summary.id,
+    label: summary.label,
+    ownBytes: summary.ownBytes,
+    ownPercentage: 0,
+    totalBytes: summary.totalBytes,
+    totalPercentage: 0,
+    occurrences: summary.occurrences,
+    stats: summary.stats,
+    samples: summary.samples ? [...summary.samples] : [],
+  };
+}
+
+function buildCoreSummaries(
+  syntax: ScriptSyntaxAnalysis,
+  scriptBytes: number,
+): AggregatedCategory[] {
+  const coverage = syntax.coverage;
+  if (!coverage) {
+    throw new Error('Core summaries require coverage information');
+  }
+
+  const summaries = new Map<string, SyntaxCategorySummary>();
+  for (const summary of syntax.categories) {
+    summaries.set(summary.id, summary);
+  }
+
+  const method = toAnalyzerCategory(
+    summaries.get('method') ?? emptySummary('method', 'Methods'),
+  );
+  const objectMethod = toAnalyzerCategory(
+    summaries.get('object_method') ??
+      emptySummary('object_method', 'Object literal methods'),
+  );
+  const fn = toAnalyzerCategory(
+    summaries.get('function') ?? emptySummary('function', 'Functions'),
+  );
+  const cls = toAnalyzerCategory(
+    summaries.get('class') ?? emptySummary('class', 'Classes'),
+  );
+
+  const unionLength = computeUnionLength([
+    coverage.method ?? [],
+    coverage.object_method ?? [],
+    coverage.function ?? [],
+    coverage.class ?? [],
+  ]);
+  const topLevelOwn = Math.max(
+    0,
+    scriptBytes -
+      (method.ownBytes + objectMethod.ownBytes + fn.ownBytes + cls.ownBytes),
+  );
+  const topLevelTotal = Math.max(0, scriptBytes - unionLength);
+
+  const topLevel: AnalyzerCategoryResult = {
+    id: 'top_level',
+    label: 'Top-level code',
+    ownBytes: topLevelOwn,
+    ownPercentage: 0,
+    totalBytes: topLevelTotal,
+    totalPercentage: 0,
+    occurrences: topLevelOwn > 0 ? 1 : 0,
+    stats: undefined,
+  };
+  return [method, objectMethod, fn, cls, { ...topLevel, samples: [] }];
+}
+
+function emptySummary(id: string, label: string): SyntaxCategorySummary {
+  return {
+    id: id as SyntaxCategoryId,
+    label,
+    ownBytes: 0,
+    ownCharacters: 0,
+    totalBytes: 0,
+    totalCharacters: 0,
+    occurrences: 0,
+    stats: undefined,
+    samples: [],
+  };
+}
+
+function computeUnionLength(segmentGroups: Segment[][]): number {
+  const allSegments = segmentGroups.flat();
+  if (!allSegments.length) {
+    return 0;
+  }
+  const sorted = allSegments.sort((a, b) => a.start - b.start);
+  let total = 0;
+  let current = { ...sorted[0] };
+  for (let i = 1; i < sorted.length; i += 1) {
+    const segment = sorted[i];
+    if (segment.start <= current.end) {
+      current.end = Math.max(current.end, segment.end);
+    } else {
+      total += Math.max(0, current.end - current.start);
+      current = { ...segment };
+    }
+  }
+  total += Math.max(0, current.end - current.start);
+  return total;
+}
+
+function calculateStats(values: number[]): CategoryStats | undefined {
+  if (!values.length) {
+    return undefined;
+  }
+  const n = values.length;
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  const average = sum / n;
+  const sumSquares = values.reduce((acc, value) => acc + value * value, 0);
+  const variance = Math.max(0, sumSquares / n - average * average);
+  const stddev = Math.sqrt(variance);
+  const sorted = [...values].sort((a, b) => a - b);
+  const percentile = (p: number) => {
+    if (n === 1) {
+      return sorted[0];
+    }
+    const rank = (p / 100) * (n - 1);
+    const low = Math.floor(rank);
+    const high = Math.min(sorted.length - 1, Math.ceil(rank));
+    if (low === high) {
+      return sorted[low];
+    }
+    const weight = rank - low;
+    return sorted[low] * (1 - weight) + sorted[high] * weight;
+  };
+
+  return {
+    average,
+    stddev,
+    p50: percentile(50),
+    p90: percentile(90),
+    p99: percentile(99),
   };
 }

--- a/libs/cli/src/har/debug.ts
+++ b/libs/cli/src/har/debug.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { loadHar } from './loader.ts';
+import { extractJavaScript } from './extract-javascript.ts';
+import { analyzeSyntax } from './syntax-attribution.ts';
+
+const harPath = process.argv[2];
+if (!harPath) {
+  console.error('Usage: tsx src/har/debug.ts <har-file>');
+  process.exit(1);
+}
+
+const main = async () => {
+  const har = await loadHar(path.resolve(harPath));
+  const extraction = extractJavaScript(har);
+  const sample = extraction.scripts.find((script) =>
+    script.body.includes('class'),
+  );
+  if (!sample) {
+    console.log('No script with class found');
+    return;
+  }
+  const syntax = analyzeSyntax(sample.body, {
+    categories: ['method', 'object_method', 'function', 'class'],
+  });
+  console.log({ url: sample.url, categories: syntax.categories });
+};
+
+main();

--- a/libs/cli/src/har/extract-javascript.spec.ts
+++ b/libs/cli/src/har/extract-javascript.spec.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it, beforeAll } from 'vitest';
+import { extractJavaScript } from './extract-javascript.ts';
+import type { HarFile } from './types.ts';
+
+let fixture: HarFile;
+
+beforeAll(async () => {
+  const raw = await readFile(
+    new URL('./__fixtures__/simple.har', import.meta.url),
+    'utf8',
+  );
+  fixture = JSON.parse(raw) as HarFile;
+});
+
+describe('extractJavaScript', () => {
+  it('returns decoded script bodies', () => {
+    const result = extractJavaScript(fixture);
+    expect(result.scripts).toHaveLength(2);
+    expect(result.scripts[1].body.trim()).toContain('export function add');
+  });
+
+  it('supports page and glob filters', () => {
+    const result = extractJavaScript(fixture, {
+      page: 'Dashboard',
+      include: '*utils*',
+    });
+    expect(result.scripts).toHaveLength(1);
+    expect(result.scripts[0].url).toContain('utils');
+  });
+});

--- a/libs/cli/src/har/extract-javascript.ts
+++ b/libs/cli/src/har/extract-javascript.ts
@@ -1,0 +1,135 @@
+import picomatch from 'picomatch';
+import type { HarEntry, HarFile, HarWarning, ScriptResource } from './types.ts';
+
+export interface ExtractionOptions {
+  page?: string;
+  include?: string;
+}
+
+export interface ExtractionResult {
+  scripts: ScriptResource[];
+  warnings: HarWarning[];
+  scannedEntries: number;
+  matchedEntries: number;
+}
+
+const JS_MIME_PATTERN = /javascript|ecmascript|module/i;
+const JS_EXTENSION_PATTERN = /\.([cm]?js|jsx|ts|tsx)(\?|$)/i;
+
+export function extractJavaScript(
+  har: HarFile,
+  options: ExtractionOptions = {},
+): ExtractionResult {
+  const matcher = options.include
+    ? picomatch(options.include, { nocase: true, contains: true, dot: true })
+    : null;
+  const warnings: HarWarning[] = [];
+  const scripts: ScriptResource[] = [];
+  const pageMatcher = buildPageMatcher(har, options.page);
+
+  let matchedEntries = 0;
+
+  for (const entry of har.log.entries) {
+    if (pageMatcher && !pageMatcher(entry.pageref)) {
+      continue;
+    }
+
+    if (!isJavaScriptEntry(entry)) {
+      continue;
+    }
+
+    const url = entry.request?.url ?? 'unknown';
+    if (matcher && !matcher(url)) {
+      continue;
+    }
+
+    matchedEntries += 1;
+
+    const content = entry.response?.content;
+    if (!content || typeof content.text !== 'string' || !content.text.length) {
+      warnings.push({
+        type: 'missing-content',
+        message: 'Response did not include body text',
+        url,
+      });
+      continue;
+    }
+
+    try {
+      const body = decodeBody(content.text, content.encoding);
+      scripts.push({
+        url,
+        mimeType: content.mimeType,
+        body,
+        bytes: Buffer.byteLength(body, 'utf8'),
+        pageRef: entry.pageref,
+      });
+    } catch (error) {
+      warnings.push({
+        type: 'parse-error',
+        message: 'Could not decode response body',
+        url,
+        details: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return {
+    scripts,
+    warnings,
+    scannedEntries: har.log.entries.length,
+    matchedEntries,
+  };
+}
+
+function buildPageMatcher(
+  har: HarFile,
+  page?: string,
+): ((pageRef?: string) => boolean) | null {
+  if (!page) {
+    return null;
+  }
+
+  const trimmed = page.trim();
+  if (!trimmed.length) {
+    return null;
+  }
+
+  const pageIds = new Set<string>();
+  if (har.log.pages) {
+    for (const candidate of har.log.pages) {
+      if (candidate.id === trimmed || candidate.title === trimmed) {
+        pageIds.add(candidate.id);
+      }
+    }
+  }
+
+  if (!pageIds.size) {
+    // Fall back to raw value to allow direct pageref matching even if not declared in pages.
+    pageIds.add(trimmed);
+  }
+
+  return (pageRef?: string) => (pageRef ? pageIds.has(pageRef) : false);
+}
+
+function isJavaScriptEntry(entry: HarEntry): boolean {
+  const mime = entry.response?.content?.mimeType;
+  if (mime && JS_MIME_PATTERN.test(mime)) {
+    return true;
+  }
+
+  const url = entry.request?.url;
+  if (url && JS_EXTENSION_PATTERN.test(url)) {
+    return true;
+  }
+
+  return false;
+}
+
+function decodeBody(text: string, encoding?: string): string {
+  if (encoding?.toLowerCase() === 'base64') {
+    return Buffer.from(text, 'base64').toString('utf8');
+  }
+
+  return text;
+}

--- a/libs/cli/src/har/find-object-methods.ts
+++ b/libs/cli/src/har/find-object-methods.ts
@@ -1,0 +1,109 @@
+import path from 'node:path';
+import { parse } from '@babel/parser';
+import type { ParserPlugin } from '@babel/parser';
+import { loadHar } from './loader.ts';
+import { extractJavaScript } from './extract-javascript.ts';
+
+const harPath = process.argv[2];
+if (!harPath) {
+  console.error('Usage: tsx src/har/find-object-methods.ts <har-file>');
+  process.exit(1);
+}
+
+const astPlugins: ParserPlugin[] = [
+  'jsx',
+  'typescript',
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'decorators-legacy',
+  'dynamicImport',
+  'importAssertions',
+  'topLevelAwait',
+];
+
+interface Sample {
+  url: string;
+  bytes: number;
+  snippet: string;
+}
+
+const THRESHOLD = 20 * 1024; // 20 KB
+const SNIPPET_LENGTH = 400;
+
+const main = async () => {
+  const har = await loadHar(path.resolve(harPath));
+  const extraction = extractJavaScript(har);
+  const samples: Sample[] = [];
+
+  for (const script of extraction.scripts) {
+    if (!script.body.includes('{')) {
+      continue;
+    }
+    let ast;
+    try {
+      ast = parse(script.body, {
+        sourceType: 'unambiguous',
+        allowReturnOutsideFunction: true,
+        allowAwaitOutsideFunction: true,
+        plugins: astPlugins,
+      });
+    } catch (error) {
+      console.warn('Failed to parse script', script.url, error);
+      continue;
+    }
+
+    const visit = (node: any) => {
+      if (!node || typeof node !== 'object') {
+        return;
+      }
+      if (node.type === 'ObjectMethod') {
+        const start = node.start ?? 0;
+        const end = node.end ?? 0;
+        if (end > start) {
+          const snippet = script.body.slice(start, start + SNIPPET_LENGTH);
+          const bytes = Buffer.byteLength(
+            script.body.slice(start, end),
+            'utf8',
+          );
+          if (bytes >= THRESHOLD) {
+            samples.push({
+              url: script.url,
+              bytes,
+              snippet,
+            });
+          }
+        }
+      }
+      for (const key of Object.keys(node)) {
+        const value = (node as any)[key];
+        if (Array.isArray(value)) {
+          for (const entry of value) {
+            visit(entry);
+          }
+        } else if (value && typeof value === 'object') {
+          visit(value);
+        }
+      }
+    };
+
+    visit(ast.program);
+  }
+
+  samples.sort((a, b) => b.bytes - a.bytes);
+  const top = samples.slice(0, 5);
+  if (!top.length) {
+    console.log('No object literal methods larger than threshold found.');
+    return;
+  }
+
+  for (const sample of top) {
+    console.log('---');
+    console.log('URL:', sample.url);
+    console.log('Size:', `${(sample.bytes / 1024).toFixed(2)} KB`);
+    console.log('Snippet:');
+    console.log(sample.snippet);
+  }
+};
+
+await main();

--- a/libs/cli/src/har/inspect-class.ts
+++ b/libs/cli/src/har/inspect-class.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { loadHar } from './loader.ts';
+import { extractJavaScript } from './extract-javascript.ts';
+import { parse } from '@babel/parser';
+import type { ParserPlugin } from '@babel/parser';
+
+const harPath = process.argv[2];
+if (!harPath) {
+  console.error('Usage: tsx src/har/inspect-class.ts <har-file>');
+  process.exit(1);
+}
+
+const harFile = path.resolve(harPath);
+
+const astPlugins: ParserPlugin[] = [
+  'jsx',
+  'typescript',
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'decorators-legacy',
+  'dynamicImport',
+  'importAssertions',
+  'topLevelAwait',
+];
+
+const main = async () => {
+  const har = await loadHar(harFile);
+  const extraction = extractJavaScript(har);
+  const sample = extraction.scripts.find((script) =>
+    script.body.includes('class'),
+  );
+  if (!sample) {
+    console.log('No script with class found');
+    return;
+  }
+
+  const ast = parse(sample.body, {
+    sourceType: 'unambiguous',
+    allowReturnOutsideFunction: true,
+    allowAwaitOutsideFunction: true,
+    plugins: astPlugins,
+  });
+
+  const classes: Array<{
+    start: number;
+    end: number;
+    children: Array<{ type: string; start: number; end: number }>;
+  }> = [];
+
+  function visit(node: any) {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+    if (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') {
+      const children = Array.isArray(node.body?.body)
+        ? node.body.body.map((child: any) => ({
+            type: child.type,
+            start: child.start,
+            end: child.end,
+          }))
+        : [];
+      classes.push({ start: node.start, end: node.end, children });
+    }
+    for (const key of Object.keys(node)) {
+      const value = (node as any)[key];
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          visit(entry);
+        }
+      } else if (value && typeof value === 'object') {
+        visit(value);
+      }
+    }
+  }
+
+  visit(ast.program);
+  console.log(
+    JSON.stringify({ url: sample.url, classes: classes.slice(0, 3) }, null, 2),
+  );
+};
+
+main();

--- a/libs/cli/src/har/loader.ts
+++ b/libs/cli/src/har/loader.ts
@@ -1,0 +1,44 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { HarFile } from './types.ts';
+
+export class HarLoaderError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'HarLoaderError';
+    this.cause = cause;
+  }
+}
+
+export async function loadHar(rawPath: string): Promise<HarFile> {
+  const resolvedPath = path.resolve(rawPath);
+  let fileContents: string;
+  try {
+    fileContents = await readFile(resolvedPath, 'utf8');
+  } catch (error) {
+    throw new HarLoaderError(
+      `Unable to read HAR file at ${resolvedPath}`,
+      error,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileContents);
+  } catch (error) {
+    throw new HarLoaderError('HAR file is not valid JSON', error);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !('log' in parsed)) {
+    throw new HarLoaderError('HAR file is missing the "log" property');
+  }
+
+  const file = parsed as HarFile;
+  if (!file.log || !Array.isArray(file.log.entries)) {
+    throw new HarLoaderError('HAR file has no entries in log.entries');
+  }
+
+  return file;
+}

--- a/libs/cli/src/har/report.ts
+++ b/libs/cli/src/har/report.ts
@@ -33,6 +33,13 @@ export function renderReport(
   const categories = applyTopFilter(result, top);
   console.log(buildTable(categories));
 
+  const statsTable = buildStatsTable(categories);
+  if (statsTable) {
+    console.log('');
+    console.log('Category stats (total bytes)');
+    console.log(statsTable);
+  }
+
   if (warnings.length) {
     console.log('');
     console.log('Warnings:');
@@ -68,11 +75,20 @@ function buildTable(categories: AnalyzerResult['categories']) {
     return 'No categories to report.';
   }
 
-  const headers = ['Category', 'Bytes', '% of total', 'Occurrences'];
+  const headers = [
+    'Category',
+    'Own bytes',
+    '% own',
+    'Total bytes',
+    '% total',
+    'Occurrences',
+  ];
   const rows = categories.map((category) => [
     category.label,
-    formatBytes(category.bytes),
-    formatPercent(category.percentage),
+    formatBytes(category.ownBytes),
+    formatPercent(category.ownPercentage),
+    formatBytes(category.totalBytes),
+    formatPercent(category.totalPercentage),
     category.occurrences.toString(),
   ]);
 
@@ -81,7 +97,7 @@ function buildTable(categories: AnalyzerResult['categories']) {
   );
 
   const lines = [];
-  lines.push(formatRow(headers, widths, [false, true, true, true]));
+  lines.push(formatRow(headers, widths, [false, true, true, true, true, true]));
   lines.push(
     formatRow(
       widths.map((w) => '-'.repeat(w)),
@@ -89,7 +105,7 @@ function buildTable(categories: AnalyzerResult['categories']) {
     ),
   );
   for (const row of rows) {
-    lines.push(formatRow(row, widths, [false, true, true, true]));
+    lines.push(formatRow(row, widths, [false, true, true, true, true, true]));
   }
   return lines.join('\n');
 }
@@ -130,4 +146,43 @@ function formatPercent(value: number): string {
     return '0%';
   }
   return `${value.toFixed(value >= 10 ? 1 : 2)}%`;
+}
+
+function buildStatsTable(categories: AnalyzerResult['categories']) {
+  const rows = categories
+    .filter((category) => category.stats)
+    .map((category) => {
+      const stats = category.stats!;
+      return [
+        category.label,
+        formatBytes(stats.average),
+        formatBytes(stats.stddev),
+        formatBytes(stats.p50),
+        formatBytes(stats.p90),
+        formatBytes(stats.p99),
+      ];
+    });
+
+  if (!rows.length) {
+    return '';
+  }
+
+  const headers = ['Category', 'Avg', 'StdDev', 'P50', 'P90', 'P99'];
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index].length)),
+  );
+
+  const lines = [];
+  lines.push(formatRow(headers, widths, [false, true, true, true, true, true]));
+  lines.push(
+    formatRow(
+      widths.map((w) => '-'.repeat(w)),
+      widths,
+    ),
+  );
+  for (const row of rows) {
+    lines.push(formatRow(row, widths, [false, true, true, true, true, true]));
+  }
+
+  return lines.join('\n');
 }

--- a/libs/cli/src/har/report.ts
+++ b/libs/cli/src/har/report.ts
@@ -1,0 +1,133 @@
+import type { AnalyzerResult } from './analyzer.ts';
+import type { HarWarning } from './types.ts';
+
+export interface ReportOptions {
+  json?: boolean;
+  top?: number;
+  warnings?: HarWarning[];
+}
+
+export function renderReport(
+  result: AnalyzerResult,
+  options: ReportOptions = {},
+) {
+  const warnings = options.warnings ?? [];
+  const top = options.top ?? 0;
+
+  if (options.json) {
+    const payload = {
+      totalBytes: result.totalBytes,
+      totalScripts: result.totalScripts,
+      categories: applyTopFilter(result, top),
+      warnings,
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log(
+    `Analyzed ${result.totalScripts} JavaScript responses (${formatBytes(result.totalBytes)})`,
+  );
+  console.log('');
+
+  const categories = applyTopFilter(result, top);
+  console.log(buildTable(categories));
+
+  if (warnings.length) {
+    console.log('');
+    console.log('Warnings:');
+    for (const warning of warnings) {
+      const source = warning.url
+        ? `${warning.message} (${warning.url})`
+        : warning.message;
+      if (warning.details) {
+        console.log(`- ${source} – ${warning.details}`);
+      } else {
+        console.log(`- ${source}`);
+      }
+    }
+  }
+}
+
+function applyTopFilter(result: AnalyzerResult, top: number) {
+  if (!top || top <= 0) {
+    return result.categories;
+  }
+
+  const main = result.categories.filter((category) => category.id !== 'other');
+  const other = result.categories.find((category) => category.id === 'other');
+  const trimmed = main.slice(0, top);
+  if (other) {
+    trimmed.push(other);
+  }
+  return trimmed;
+}
+
+function buildTable(categories: AnalyzerResult['categories']) {
+  if (!categories.length) {
+    return 'No categories to report.';
+  }
+
+  const headers = ['Category', 'Bytes', '% of total', 'Occurrences'];
+  const rows = categories.map((category) => [
+    category.label,
+    formatBytes(category.bytes),
+    formatPercent(category.percentage),
+    category.occurrences.toString(),
+  ]);
+
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index].length)),
+  );
+
+  const lines = [];
+  lines.push(formatRow(headers, widths, [false, true, true, true]));
+  lines.push(
+    formatRow(
+      widths.map((w) => '-'.repeat(w)),
+      widths,
+    ),
+  );
+  for (const row of rows) {
+    lines.push(formatRow(row, widths, [false, true, true, true]));
+  }
+  return lines.join('\n');
+}
+
+function formatRow(
+  cells: string[],
+  widths: number[],
+  numericColumns: boolean[] = [],
+): string {
+  return cells
+    .map((cell, index) => pad(cell, widths[index], numericColumns[index]))
+    .join('  ');
+}
+
+function pad(value: string, width: number, numeric?: boolean) {
+  if (numeric) {
+    return value.padStart(width, ' ');
+  }
+  return value.padEnd(width, ' ');
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let index = 0;
+  let current = bytes;
+  while (current >= 1024 && index < units.length - 1) {
+    current /= 1024;
+    index += 1;
+  }
+  return `${current.toFixed(current >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)}%`;
+}

--- a/libs/cli/src/har/syntax-attribution.spec.ts
+++ b/libs/cli/src/har/syntax-attribution.spec.ts
@@ -37,14 +37,76 @@ describe('analyzeSyntax', () => {
     );
 
     expect(analysis.bytes).toBeGreaterThan(0);
-    expect(classCategory?.bytes).toBeGreaterThan(0);
+    expect(classCategory?.ownBytes).toBeGreaterThan(0);
     expect(stringCategory?.occurrences).toBeGreaterThanOrEqual(2);
     expect(templateCategory?.occurrences).toBe(1);
     expect(importCategory?.occurrences).toBe(3);
     const totalCategoryBytes = analysis.categories.reduce(
-      (sum, item) => sum + item.bytes,
+      (sum, item) => sum + item.ownBytes,
       0,
     );
     expect(totalCategoryBytes).toBe(analysis.bytes);
+  });
+
+  it('separates object literal methods into their own category', () => {
+    const code = 'const obj = { foo() { return 1; } };';
+    const analysis = analyzeSyntax(code, {
+      categories: ['method', 'object_method', 'function'],
+    });
+
+    const objectMethodCategory = analysis.categories.find(
+      (item) => item.id === 'object_method',
+    );
+    const functionCategory = analysis.categories.find(
+      (item) => item.id === 'function',
+    );
+
+    expect(objectMethodCategory?.occurrences).toBe(1);
+    expect(functionCategory).toBeUndefined();
+  });
+
+  it('attributes class shells (fields, static blocks) exactly to classes', () => {
+    const methodSource = 'baz() { return this.bar; }';
+    const classPrefix = 'class Foo { bar = 1; static { this.bar; } ';
+    const classSuffix = ' }';
+    const code = `${classPrefix}${methodSource}${classSuffix}`;
+    const analysis = analyzeSyntax(code, {
+      categories: ['class', 'method'],
+    });
+
+    const classCategory = analysis.categories.find(
+      (item) => item.id === 'class',
+    );
+    const methodCategory = analysis.categories.find(
+      (item) => item.id === 'method',
+    );
+
+    const methodBytes = Buffer.byteLength(methodSource, 'utf8');
+    const totalBytes = Buffer.byteLength(code, 'utf8');
+    const classBytes = Buffer.byteLength(classPrefix + classSuffix, 'utf8');
+    const expectedClassBytes = totalBytes - methodBytes;
+
+    expect(methodCategory?.ownBytes).toBe(methodBytes);
+    expect(classCategory?.ownBytes).toBe(classBytes);
+    expect(classCategory?.ownBytes).toBe(expectedClassBytes);
+    expect(classCategory?.totalBytes).toBe(totalBytes);
+  });
+
+  it('detects bundled module object methods', () => {
+    const code =
+      'const chunk = { 43623(e,t,n){return e+t+n;}, foo(){return 1;} };';
+    const analysis = analyzeSyntax(code, {
+      categories: ['bundle_module', 'object_method'],
+    });
+
+    const bundle = analysis.categories.find(
+      (item) => item.id === 'bundle_module',
+    );
+    const objectMethod = analysis.categories.find(
+      (item) => item.id === 'object_method',
+    );
+
+    expect(bundle?.occurrences).toBe(1);
+    expect(objectMethod?.occurrences).toBe(1);
   });
 });

--- a/libs/cli/src/har/syntax-attribution.spec.ts
+++ b/libs/cli/src/har/syntax-attribution.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeSyntax } from './syntax-attribution.ts';
+
+describe('analyzeSyntax', () => {
+  it('categorizes major syntax constructs', () => {
+    const code =
+      `
+      import { useMemo } from 'react';
+      export class Widget {
+        constructor() {
+          this.label = 'Hello';
+        }
+        render() {
+          const data = ['a', "b"].map((value) => value.toUpperCase());
+          return data.join(',');
+        }
+      }
+      export function helper() {
+        return ` +
+      '`value:${Math.random()}`' +
+      `;
+      }
+    `;
+
+    const analysis = analyzeSyntax(code);
+    const classCategory = analysis.categories.find(
+      (item) => item.id === 'class',
+    );
+    const stringCategory = analysis.categories.find(
+      (item) => item.id === 'string_literal',
+    );
+    const templateCategory = analysis.categories.find(
+      (item) => item.id === 'template_literal',
+    );
+    const importCategory = analysis.categories.find(
+      (item) => item.id === 'import_export',
+    );
+
+    expect(analysis.bytes).toBeGreaterThan(0);
+    expect(classCategory?.bytes).toBeGreaterThan(0);
+    expect(stringCategory?.occurrences).toBeGreaterThanOrEqual(2);
+    expect(templateCategory?.occurrences).toBe(1);
+    expect(importCategory?.occurrences).toBe(3);
+    const totalCategoryBytes = analysis.categories.reduce(
+      (sum, item) => sum + item.bytes,
+      0,
+    );
+    expect(totalCategoryBytes).toBe(analysis.bytes);
+  });
+});

--- a/libs/cli/src/har/syntax-attribution.ts
+++ b/libs/cli/src/har/syntax-attribution.ts
@@ -1,10 +1,12 @@
 import { parse } from '@babel/parser';
-import type { Node } from '@babel/types';
+import type { Node, ObjectMethod } from '@babel/types';
 
 export type SyntaxCategoryId =
   | 'class'
   | 'function'
   | 'method'
+  | 'bundle_module'
+  | 'object_method'
   | 'string_literal'
   | 'template_literal'
   | 'import_export'
@@ -12,18 +14,36 @@ export type SyntaxCategoryId =
   | 'comment'
   | 'other';
 
+export interface SyntaxAnalysisOptions {
+  categories?: SyntaxCategoryId[];
+  includeCoverage?: boolean;
+}
+
+export interface CategoryStats {
+  average: number;
+  stddev: number;
+  p50: number;
+  p90: number;
+  p99: number;
+}
+
 export interface SyntaxCategorySummary {
   id: SyntaxCategoryId;
   label: string;
-  bytes: number;
-  characters: number;
+  ownBytes: number;
+  ownCharacters: number;
+  totalBytes: number;
+  totalCharacters: number;
   occurrences: number;
+  stats?: CategoryStats;
+  samples?: number[];
 }
 
 export interface ScriptSyntaxAnalysis {
   bytes: number;
   characters: number;
   categories: SyntaxCategorySummary[];
+  coverage?: Record<string, Segment[]>;
 }
 
 interface Segment {
@@ -37,7 +57,9 @@ const CATEGORY_INFO: Record<
 > = {
   string_literal: { label: 'String literals', priority: 10 },
   template_literal: { label: 'Template literals', priority: 9 },
-  method: { label: 'Methods', priority: 8 },
+  method: { label: 'Methods', priority: 8.5 },
+  bundle_module: { label: 'Bundled modules', priority: 8 },
+  object_method: { label: 'Object literal methods', priority: 7.5 },
   function: { label: 'Functions', priority: 7 },
   class: { label: 'Classes', priority: 6 },
   import_export: { label: 'Imports/exports', priority: 5 },
@@ -45,35 +67,29 @@ const CATEGORY_INFO: Record<
   comment: { label: 'Comments', priority: 1 },
 };
 
-const CATEGORY_ORDER = Object.entries(CATEGORY_INFO)
+const DEFAULT_CATEGORY_ORDER = Object.entries(CATEGORY_INFO)
   .sort((a, b) => b[1].priority - a[1].priority)
   .map(([id]) => id as Exclude<SyntaxCategoryId, 'other'>);
 
-export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
+export function analyzeSyntax(
+  source: string,
+  options: SyntaxAnalysisOptions = {},
+): ScriptSyntaxAnalysis {
+  const categories: SyntaxCategoryId[] = (
+    options.categories ? [...options.categories] : [...DEFAULT_CATEGORY_ORDER]
+  ).sort((a, b) => getPriority(b) - getPriority(a));
+  const categorySet = new Set(categories);
   const ast = parseSource(source);
-  const groupedIntervals: Record<
-    Exclude<SyntaxCategoryId, 'other'>,
-    Segment[]
-  > = {
-    class: [],
-    function: [],
-    method: [],
-    string_literal: [],
-    template_literal: [],
-    import_export: [],
-    object_literal: [],
-    comment: [],
-  };
-  const occurrences: Record<Exclude<SyntaxCategoryId, 'other'>, number> = {
-    class: 0,
-    function: 0,
-    method: 0,
-    string_literal: 0,
-    template_literal: 0,
-    import_export: 0,
-    object_literal: 0,
-    comment: 0,
-  };
+
+  const groupedIntervals: Record<string, Segment[]> = {};
+  const occurrences: Record<string, number> = {};
+  const sampleMap: Record<string, number[]> = {};
+  const classShells: Segment[] = [];
+  for (const category of categories) {
+    groupedIntervals[category] = [];
+    occurrences[category] = 0;
+    sampleMap[category] = [];
+  }
 
   visitNode(ast.program as Node, (node) => {
     if (!hasRange(node)) {
@@ -83,83 +99,178 @@ export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
     switch (node.type) {
       case 'ClassDeclaration':
       case 'ClassExpression':
-        addInterval(
-          groupedIntervals.class,
-          node.start,
-          node.end,
-          occurrences,
-          'class',
-        );
+        if (categorySet.has('class')) {
+          addInterval(
+            groupedIntervals.class,
+            node.start,
+            node.end,
+            occurrences,
+            'class',
+          );
+          classShells.push(...collectClassShells(node));
+          recordSample(sampleMap, 'class', source, node.start, node.end);
+        }
         break;
       case 'FunctionDeclaration':
       case 'FunctionExpression':
       case 'ArrowFunctionExpression':
-        addInterval(
-          groupedIntervals.function,
-          node.start,
-          node.end,
-          occurrences,
-          'function',
-        );
+        if (categorySet.has('function')) {
+          addInterval(
+            groupedIntervals.function,
+            node.start,
+            node.end,
+            occurrences,
+            'function',
+          );
+          recordSample(sampleMap, 'function', source, node.start, node.end);
+        }
         break;
       case 'ClassMethod':
       case 'ClassPrivateMethod':
-      case 'ObjectMethod':
       case 'TSDeclareMethod':
-        addInterval(
-          groupedIntervals.method,
-          node.start,
-          node.end,
-          occurrences,
-          'method',
-        );
+        if (categorySet.has('method')) {
+          addInterval(
+            groupedIntervals.method,
+            node.start,
+            node.end,
+            occurrences,
+            'method',
+          );
+          recordSample(sampleMap, 'method', source, node.start, node.end);
+        }
+        break;
+      case 'ObjectMethod':
+        if (isBundlerObjectMethod(node)) {
+          if (categorySet.has('bundle_module')) {
+            addInterval(
+              groupedIntervals.bundle_module,
+              node.start,
+              node.end,
+              occurrences,
+              'bundle_module',
+            );
+            recordSample(
+              sampleMap,
+              'bundle_module',
+              source,
+              node.start,
+              node.end,
+            );
+          } else if (categorySet.has('object_method')) {
+            addInterval(
+              groupedIntervals.object_method,
+              node.start,
+              node.end,
+              occurrences,
+              'object_method',
+            );
+            recordSample(
+              sampleMap,
+              'object_method',
+              source,
+              node.start,
+              node.end,
+            );
+          }
+        } else if (categorySet.has('object_method')) {
+          addInterval(
+            groupedIntervals.object_method,
+            node.start,
+            node.end,
+            occurrences,
+            'object_method',
+          );
+          recordSample(
+            sampleMap,
+            'object_method',
+            source,
+            node.start,
+            node.end,
+          );
+        }
         break;
       case 'StringLiteral':
-        addInterval(
-          groupedIntervals.string_literal,
-          node.start,
-          node.end,
-          occurrences,
-          'string_literal',
-        );
+        if (categorySet.has('string_literal')) {
+          addInterval(
+            groupedIntervals.string_literal,
+            node.start,
+            node.end,
+            occurrences,
+            'string_literal',
+          );
+          recordSample(
+            sampleMap,
+            'string_literal',
+            source,
+            node.start,
+            node.end,
+          );
+        }
         break;
       case 'TemplateLiteral':
-        addInterval(
-          groupedIntervals.template_literal,
-          node.start,
-          node.end,
-          occurrences,
-          'template_literal',
-        );
+        if (categorySet.has('template_literal')) {
+          addInterval(
+            groupedIntervals.template_literal,
+            node.start,
+            node.end,
+            occurrences,
+            'template_literal',
+          );
+          recordSample(
+            sampleMap,
+            'template_literal',
+            source,
+            node.start,
+            node.end,
+          );
+        }
         break;
       case 'ImportDeclaration':
       case 'ExportDefaultDeclaration':
       case 'ExportNamedDeclaration':
       case 'ExportAllDeclaration':
       case 'ImportExpression':
-        addInterval(
-          groupedIntervals.import_export,
-          node.start,
-          node.end,
-          occurrences,
-          'import_export',
-        );
+        if (categorySet.has('import_export')) {
+          addInterval(
+            groupedIntervals.import_export,
+            node.start,
+            node.end,
+            occurrences,
+            'import_export',
+          );
+          recordSample(
+            sampleMap,
+            'import_export',
+            source,
+            node.start,
+            node.end,
+          );
+        }
         break;
       case 'ObjectExpression':
-        addInterval(
-          groupedIntervals.object_literal,
-          node.start,
-          node.end,
-          occurrences,
-          'object_literal',
-        );
+        if (categorySet.has('object_literal')) {
+          addInterval(
+            groupedIntervals.object_literal,
+            node.start,
+            node.end,
+            occurrences,
+            'object_literal',
+          );
+          recordSample(
+            sampleMap,
+            'object_literal',
+            source,
+            node.start,
+            node.end,
+          );
+        }
         break;
       default:
         break;
     }
   });
 
-  if (Array.isArray((ast as any).comments)) {
+  if (categorySet.has('comment') && Array.isArray((ast as any).comments)) {
     for (const comment of (ast as any).comments as Array<{
       start: number;
       end: number;
@@ -175,24 +286,25 @@ export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
           occurrences,
           'comment',
         );
+        recordSample(sampleMap, 'comment', source, comment.start, comment.end);
       }
     }
   }
 
   const occupied: Segment[] = [];
-  const attributed: Record<Exclude<SyntaxCategoryId, 'other'>, Segment[]> = {
-    class: [],
-    function: [],
-    method: [],
-    string_literal: [],
-    template_literal: [],
-    import_export: [],
-    object_literal: [],
-    comment: [],
-  };
+  const attributed: Record<string, Segment[]> = {};
+  for (const category of categories) {
+    attributed[category] = [];
+  }
 
-  for (const category of CATEGORY_ORDER) {
-    const merged = mergeSegments(groupedIntervals[category]);
+  const coverage: Record<string, Segment[]> | undefined =
+    options.includeCoverage ? {} : undefined;
+
+  for (const category of categories) {
+    const merged = mergeSegments(groupedIntervals[category] ?? []);
+    if (coverage) {
+      coverage[category] = merged.map((segment) => ({ ...segment }));
+    }
     const available: Segment[] = [];
     for (const segment of merged) {
       const remainder = subtractSegment(segment, occupied);
@@ -210,23 +322,38 @@ export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
   let accountedBytes = 0;
   let accountedChars = 0;
 
-  for (const category of CATEGORY_ORDER) {
-    const segments = mergeSegments(attributed[category]);
-    if (!segments.length) {
+  for (const category of categories) {
+    let exclusiveSegments = mergeSegments(attributed[category] ?? []);
+    if (category === 'class' && classShells.length) {
+      exclusiveSegments = mergeSegments(classShells);
+    }
+    const inclusiveSegments = mergeSegments(groupedIntervals[category] ?? []);
+    const ownBytes = sumBytes(source, exclusiveSegments);
+    const ownChars = sumCharacters(exclusiveSegments);
+    const totalBytesForCategory = sumBytes(source, inclusiveSegments);
+    const totalCharsForCategory = sumCharacters(inclusiveSegments);
+
+    accountedBytes += ownBytes;
+    accountedChars += ownChars;
+
+    if (!ownBytes && !totalBytesForCategory) {
       continue;
     }
 
-    const bytes = sumBytes(source, segments);
-    const chars = sumCharacters(segments);
-    accountedBytes += bytes;
-    accountedChars += chars;
+    const samplesForCategory = sampleMap[category] ?? [];
 
     summaries.push({
       id: category,
-      label: CATEGORY_INFO[category].label,
-      bytes,
-      characters: chars,
-      occurrences: occurrences[category],
+      label:
+        CATEGORY_INFO[category as Exclude<SyntaxCategoryId, 'other'>]?.label ??
+        category,
+      ownBytes,
+      ownCharacters: ownChars,
+      totalBytes: totalBytesForCategory,
+      totalCharacters: totalCharsForCategory,
+      occurrences: occurrences[category] ?? 0,
+      stats: computeStats(samplesForCategory),
+      samples: samplesForCategory.length ? [...samplesForCategory] : [],
     });
   }
 
@@ -236,15 +363,20 @@ export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
   summaries.push({
     id: 'other',
     label: 'Other',
-    bytes: remainingBytes,
-    characters: remainingChars,
+    ownBytes: remainingBytes,
+    ownCharacters: remainingChars,
+    totalBytes: remainingBytes,
+    totalCharacters: remainingChars,
     occurrences: 0,
+    stats: undefined,
+    samples: [],
   });
 
   return {
     bytes: totalBytes,
     characters: totalCharacters,
     categories: summaries,
+    coverage,
   };
 }
 
@@ -309,14 +441,14 @@ function addInterval(
   list: Segment[],
   start: number,
   end: number,
-  occurrences: Record<Exclude<SyntaxCategoryId, 'other'>, number>,
+  occurrences: Record<string, number>,
   category: Exclude<SyntaxCategoryId, 'other'>,
 ) {
   if (start >= end) {
     return;
   }
   list.push({ start, end });
-  occurrences[category] += 1;
+  occurrences[category] = (occurrences[category] ?? 0) + 1;
 }
 
 function mergeSegments(segments: Segment[]): Segment[] {
@@ -338,6 +470,47 @@ function mergeSegments(segments: Segment[]): Segment[] {
     }
   }
   return merged;
+}
+
+function collectClassShells(node: Node): Segment[] {
+  if (
+    typeof (node as any).start !== 'number' ||
+    typeof (node as any).end !== 'number'
+  ) {
+    return [];
+  }
+
+  const body =
+    node && typeof node === 'object' && 'body' in node
+      ? ((node as any).body?.body as Node[] | undefined)
+      : undefined;
+  const children = body ?? [];
+
+  let shells: Segment[] = [
+    { start: (node as any).start, end: (node as any).end },
+  ];
+  for (const child of children) {
+    if (!CLASS_CHILD_EXCLUDE.has(child.type)) {
+      continue;
+    }
+    if (
+      typeof (child as any).start !== 'number' ||
+      typeof (child as any).end !== 'number'
+    ) {
+      continue;
+    }
+    const childSegment = {
+      start: (child as any).start,
+      end: (child as any).end,
+    };
+    const updated: Segment[] = [];
+    for (const segment of shells) {
+      updated.push(...subtractSegment(segment, [childSegment]));
+    }
+    shells = updated;
+  }
+
+  return shells.filter((segment) => segment.end > segment.start);
 }
 
 function subtractSegment(segment: Segment, occupied: Segment[]): Segment[] {
@@ -404,3 +577,97 @@ function sumCharacters(segments: Segment[]): number {
     0,
   );
 }
+
+export type { Segment };
+
+function getPriority(category: SyntaxCategoryId): number {
+  return (
+    CATEGORY_INFO[category as Exclude<SyntaxCategoryId, 'other'>]?.priority ?? 0
+  );
+}
+
+function recordSample(
+  samples: Record<string, number[]>,
+  category: SyntaxCategoryId,
+  source: string,
+  start: number,
+  end: number,
+) {
+  if (!samples[category]) {
+    samples[category] = [];
+  }
+  const length = Math.max(0, end - start);
+  if (!length) {
+    return;
+  }
+  samples[category].push(Buffer.byteLength(source.slice(start, end), 'utf8'));
+}
+
+function computeStats(values: number[]): CategoryStats | undefined {
+  if (!values.length) {
+    return undefined;
+  }
+  const n = values.length;
+  const sum = values.reduce((acc, value) => acc + value, 0);
+  const average = sum / n;
+  const sumSquares = values.reduce((acc, value) => acc + value * value, 0);
+  const variance = Math.max(0, sumSquares / n - average * average);
+  const stddev = Math.sqrt(variance);
+  const sorted = [...values].sort((a, b) => a - b);
+  const percentile = (p: number) => {
+    if (n === 1) {
+      return sorted[0];
+    }
+    const rank = (p / 100) * (n - 1);
+    const low = Math.floor(rank);
+    const high = Math.min(sorted.length - 1, Math.ceil(rank));
+    if (low === high) {
+      return sorted[low];
+    }
+    const weight = rank - low;
+    return sorted[low] * (1 - weight) + sorted[high] * weight;
+  };
+
+  return {
+    average,
+    stddev,
+    p50: percentile(50),
+    p90: percentile(90),
+    p99: percentile(99),
+  };
+}
+
+function isBundlerObjectMethod(node: ObjectMethod): boolean {
+  if (node.kind && node.kind !== 'method') {
+    return false;
+  }
+  const key = (node as any).key;
+  if (!key) {
+    return false;
+  }
+  let numericKey = false;
+  if (key.type === 'NumericLiteral') {
+    numericKey = true;
+  } else if (key.type === 'StringLiteral' && /^\d+$/.test(String(key.value))) {
+    numericKey = true;
+  } else if (
+    !node.computed &&
+    key.type === 'Identifier' &&
+    /^\d+$/.test(key.name)
+  ) {
+    numericKey = true;
+  }
+  if (!numericKey) {
+    return false;
+  }
+  const params = Array.isArray(node.params) ? node.params : [];
+  if (params.length < 2 || params.length > 4) {
+    return false;
+  }
+  return true;
+}
+const CLASS_CHILD_EXCLUDE = new Set([
+  'ClassMethod',
+  'ClassPrivateMethod',
+  'TSDeclareMethod',
+]);

--- a/libs/cli/src/har/syntax-attribution.ts
+++ b/libs/cli/src/har/syntax-attribution.ts
@@ -1,0 +1,406 @@
+import { parse } from '@babel/parser';
+import type { Node } from '@babel/types';
+
+export type SyntaxCategoryId =
+  | 'class'
+  | 'function'
+  | 'method'
+  | 'string_literal'
+  | 'template_literal'
+  | 'import_export'
+  | 'object_literal'
+  | 'comment'
+  | 'other';
+
+export interface SyntaxCategorySummary {
+  id: SyntaxCategoryId;
+  label: string;
+  bytes: number;
+  characters: number;
+  occurrences: number;
+}
+
+export interface ScriptSyntaxAnalysis {
+  bytes: number;
+  characters: number;
+  categories: SyntaxCategorySummary[];
+}
+
+interface Segment {
+  start: number;
+  end: number;
+}
+
+const CATEGORY_INFO: Record<
+  Exclude<SyntaxCategoryId, 'other'>,
+  { label: string; priority: number }
+> = {
+  string_literal: { label: 'String literals', priority: 10 },
+  template_literal: { label: 'Template literals', priority: 9 },
+  method: { label: 'Methods', priority: 8 },
+  function: { label: 'Functions', priority: 7 },
+  class: { label: 'Classes', priority: 6 },
+  import_export: { label: 'Imports/exports', priority: 5 },
+  object_literal: { label: 'Object literals', priority: 4 },
+  comment: { label: 'Comments', priority: 1 },
+};
+
+const CATEGORY_ORDER = Object.entries(CATEGORY_INFO)
+  .sort((a, b) => b[1].priority - a[1].priority)
+  .map(([id]) => id as Exclude<SyntaxCategoryId, 'other'>);
+
+export function analyzeSyntax(source: string): ScriptSyntaxAnalysis {
+  const ast = parseSource(source);
+  const groupedIntervals: Record<
+    Exclude<SyntaxCategoryId, 'other'>,
+    Segment[]
+  > = {
+    class: [],
+    function: [],
+    method: [],
+    string_literal: [],
+    template_literal: [],
+    import_export: [],
+    object_literal: [],
+    comment: [],
+  };
+  const occurrences: Record<Exclude<SyntaxCategoryId, 'other'>, number> = {
+    class: 0,
+    function: 0,
+    method: 0,
+    string_literal: 0,
+    template_literal: 0,
+    import_export: 0,
+    object_literal: 0,
+    comment: 0,
+  };
+
+  visitNode(ast.program as Node, (node) => {
+    if (!hasRange(node)) {
+      return;
+    }
+
+    switch (node.type) {
+      case 'ClassDeclaration':
+      case 'ClassExpression':
+        addInterval(
+          groupedIntervals.class,
+          node.start,
+          node.end,
+          occurrences,
+          'class',
+        );
+        break;
+      case 'FunctionDeclaration':
+      case 'FunctionExpression':
+      case 'ArrowFunctionExpression':
+        addInterval(
+          groupedIntervals.function,
+          node.start,
+          node.end,
+          occurrences,
+          'function',
+        );
+        break;
+      case 'ClassMethod':
+      case 'ClassPrivateMethod':
+      case 'ObjectMethod':
+      case 'TSDeclareMethod':
+        addInterval(
+          groupedIntervals.method,
+          node.start,
+          node.end,
+          occurrences,
+          'method',
+        );
+        break;
+      case 'StringLiteral':
+        addInterval(
+          groupedIntervals.string_literal,
+          node.start,
+          node.end,
+          occurrences,
+          'string_literal',
+        );
+        break;
+      case 'TemplateLiteral':
+        addInterval(
+          groupedIntervals.template_literal,
+          node.start,
+          node.end,
+          occurrences,
+          'template_literal',
+        );
+        break;
+      case 'ImportDeclaration':
+      case 'ExportDefaultDeclaration':
+      case 'ExportNamedDeclaration':
+      case 'ExportAllDeclaration':
+      case 'ImportExpression':
+        addInterval(
+          groupedIntervals.import_export,
+          node.start,
+          node.end,
+          occurrences,
+          'import_export',
+        );
+        break;
+      case 'ObjectExpression':
+        addInterval(
+          groupedIntervals.object_literal,
+          node.start,
+          node.end,
+          occurrences,
+          'object_literal',
+        );
+        break;
+      default:
+        break;
+    }
+  });
+
+  if (Array.isArray((ast as any).comments)) {
+    for (const comment of (ast as any).comments as Array<{
+      start: number;
+      end: number;
+    }>) {
+      if (
+        typeof comment.start === 'number' &&
+        typeof comment.end === 'number'
+      ) {
+        addInterval(
+          groupedIntervals.comment,
+          comment.start,
+          comment.end,
+          occurrences,
+          'comment',
+        );
+      }
+    }
+  }
+
+  const occupied: Segment[] = [];
+  const attributed: Record<Exclude<SyntaxCategoryId, 'other'>, Segment[]> = {
+    class: [],
+    function: [],
+    method: [],
+    string_literal: [],
+    template_literal: [],
+    import_export: [],
+    object_literal: [],
+    comment: [],
+  };
+
+  for (const category of CATEGORY_ORDER) {
+    const merged = mergeSegments(groupedIntervals[category]);
+    const available: Segment[] = [];
+    for (const segment of merged) {
+      const remainder = subtractSegment(segment, occupied);
+      available.push(...remainder);
+    }
+    attributed[category] = mergeSegments(available);
+    occupied.push(...available);
+    occupied.sort((a, b) => a.start - b.start);
+    mergeInto(occupied);
+  }
+
+  const totalBytes = Buffer.byteLength(source, 'utf8');
+  const totalCharacters = source.length;
+  const summaries: SyntaxCategorySummary[] = [];
+  let accountedBytes = 0;
+  let accountedChars = 0;
+
+  for (const category of CATEGORY_ORDER) {
+    const segments = mergeSegments(attributed[category]);
+    if (!segments.length) {
+      continue;
+    }
+
+    const bytes = sumBytes(source, segments);
+    const chars = sumCharacters(segments);
+    accountedBytes += bytes;
+    accountedChars += chars;
+
+    summaries.push({
+      id: category,
+      label: CATEGORY_INFO[category].label,
+      bytes,
+      characters: chars,
+      occurrences: occurrences[category],
+    });
+  }
+
+  const remainingBytes = Math.max(0, totalBytes - accountedBytes);
+  const remainingChars = Math.max(0, totalCharacters - accountedChars);
+
+  summaries.push({
+    id: 'other',
+    label: 'Other',
+    bytes: remainingBytes,
+    characters: remainingChars,
+    occurrences: 0,
+  });
+
+  return {
+    bytes: totalBytes,
+    characters: totalCharacters,
+    categories: summaries,
+  };
+}
+
+function parseSource(source: string) {
+  return parse(source, {
+    sourceType: 'unambiguous',
+    allowReturnOutsideFunction: true,
+    allowAwaitOutsideFunction: true,
+    plugins: [
+      'jsx',
+      'typescript',
+      'classProperties',
+      'classPrivateProperties',
+      'classPrivateMethods',
+      'decorators-legacy',
+      'dynamicImport',
+      'importAssertions',
+      'topLevelAwait',
+    ],
+    ranges: true,
+  });
+}
+
+function visitNode(node: Node, visitor: (node: Node) => void) {
+  const stack: Node[] = [node];
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    visitor(current);
+    for (const key of Object.keys(current as object)) {
+      const value = (current as any)[key];
+      if (!value) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (isNode(item)) {
+            stack.push(item);
+          }
+        }
+      } else if (isNode(value)) {
+        stack.push(value);
+      }
+    }
+  }
+}
+
+function isNode(value: unknown): value is Node {
+  return Boolean(value && typeof value === 'object' && 'type' in value);
+}
+
+function hasRange(node: Node): node is Node & { start: number; end: number } {
+  return (
+    typeof (node as any).start === 'number' &&
+    typeof (node as any).end === 'number'
+  );
+}
+
+function addInterval(
+  list: Segment[],
+  start: number,
+  end: number,
+  occurrences: Record<Exclude<SyntaxCategoryId, 'other'>, number>,
+  category: Exclude<SyntaxCategoryId, 'other'>,
+) {
+  if (start >= end) {
+    return;
+  }
+  list.push({ start, end });
+  occurrences[category] += 1;
+}
+
+function mergeSegments(segments: Segment[]): Segment[] {
+  if (!segments.length) {
+    return [];
+  }
+  const sorted = [...segments].sort((a, b) => a.start - b.start);
+  const merged: Segment[] = [];
+  for (const segment of sorted) {
+    const last = merged.at(-1);
+    if (!last) {
+      merged.push({ ...segment });
+      continue;
+    }
+    if (segment.start <= last.end) {
+      last.end = Math.max(last.end, segment.end);
+    } else {
+      merged.push({ ...segment });
+    }
+  }
+  return merged;
+}
+
+function subtractSegment(segment: Segment, occupied: Segment[]): Segment[] {
+  if (!occupied.length) {
+    return [segment];
+  }
+
+  const result: Segment[] = [];
+  let cursor = segment.start;
+  const end = segment.end;
+
+  for (const taken of occupied) {
+    if (taken.end <= cursor) {
+      continue;
+    }
+    if (taken.start >= end) {
+      break;
+    }
+    if (taken.start > cursor) {
+      result.push({ start: cursor, end: Math.min(taken.start, end) });
+    }
+    cursor = Math.max(cursor, taken.end);
+    if (cursor >= end) {
+      break;
+    }
+  }
+
+  if (cursor < end) {
+    result.push({ start: cursor, end });
+  }
+
+  return result.filter((part) => part.end > part.start);
+}
+
+function mergeInto(segments: Segment[]) {
+  segments.sort((a, b) => a.start - b.start);
+  let i = 0;
+  while (i < segments.length - 1) {
+    const current = segments[i];
+    const next = segments[i + 1];
+    if (current.end >= next.start) {
+      current.end = Math.max(current.end, next.end);
+      segments.splice(i + 1, 1);
+    } else {
+      i += 1;
+    }
+  }
+}
+
+function sumBytes(source: string, segments: Segment[]): number {
+  let total = 0;
+  for (const segment of segments) {
+    total += Buffer.byteLength(
+      source.slice(segment.start, segment.end),
+      'utf8',
+    );
+  }
+  return total;
+}
+
+function sumCharacters(segments: Segment[]): number {
+  return segments.reduce(
+    (sum, segment) => sum + (segment.end - segment.start),
+    0,
+  );
+}

--- a/libs/cli/src/har/types.ts
+++ b/libs/cli/src/har/types.ts
@@ -1,0 +1,65 @@
+export interface HarContent {
+  text?: string;
+  size?: number;
+  compression?: number;
+  mimeType?: string;
+  encoding?: string;
+}
+
+export interface HarResponse {
+  status: number;
+  content: HarContent;
+  headers?: Array<{ name: string; value: string }>;
+}
+
+export interface HarRequest {
+  url: string;
+  method: string;
+  headers?: Array<{ name: string; value: string }>;
+}
+
+export interface HarEntry {
+  pageref?: string;
+  startedDateTime: string;
+  time: number;
+  request: HarRequest;
+  response: HarResponse;
+}
+
+export interface HarPage {
+  id: string;
+  title?: string;
+  comment?: string;
+}
+
+export interface HarLog {
+  version: string;
+  creator?: { name: string; version: string };
+  pages?: HarPage[];
+  entries: HarEntry[];
+}
+
+export interface HarFile {
+  log: HarLog;
+}
+
+export interface ScriptResource {
+  url: string;
+  mimeType?: string;
+  body: string;
+  bytes: number;
+  pageRef?: string;
+}
+
+export type HarWarningType =
+  | 'missing-content'
+  | 'parse-error'
+  | 'empty-log'
+  | 'filter';
+
+export interface HarWarning {
+  type: HarWarningType;
+  message: string;
+  url?: string;
+  details?: string;
+}

--- a/libs/cli/src/main.ts
+++ b/libs/cli/src/main.ts
@@ -54,6 +54,10 @@ program
     'Only include entries from a specific HAR page',
   )
   .option('--include <pattern>', 'Glob pattern to match script request URLs')
+  .option(
+    '--mode <mode>',
+    'Analysis mode: full (default) or core (methods/functions/classes/top-level)',
+  )
   .option('-t, --top <n>', 'Limit output to the top N categories')
   .option('-j, --json', 'Print the report as JSON')
   .action(
@@ -64,6 +68,7 @@ program
         include?: string;
         top?: string;
         json?: boolean;
+        mode?: string;
       },
     ) => {
       try {

--- a/libs/cli/src/main.ts
+++ b/libs/cli/src/main.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { fileURLToPath } from 'node:url';
 import pkgJSON from '../package.json' with { type: 'json' };
 import { analyzeCommand } from './cmds/analyze.ts';
+import { analyzeHarCommand } from './cmds/analyze-har.ts';
 import { listCommand } from './cmds/list.ts';
 
 const program = new Command();
@@ -33,6 +34,40 @@ program
     ) => {
       try {
         const code = await analyzeCommand(projectPath, options);
+        process.exit(code);
+      } catch (error) {
+        console.error(
+          'Error:',
+          error instanceof Error ? error.message : String(error),
+        );
+        process.exit(1);
+      }
+    },
+  );
+
+program
+  .command('analyze-har')
+  .description('Analyze JavaScript usage from a HAR export')
+  .argument('<har-file>', 'Path to the HAR file to analyze')
+  .option(
+    '--page <id-or-name>',
+    'Only include entries from a specific HAR page',
+  )
+  .option('--include <pattern>', 'Glob pattern to match script request URLs')
+  .option('-t, --top <n>', 'Limit output to the top N categories')
+  .option('-j, --json', 'Print the report as JSON')
+  .action(
+    async (
+      harFile: string,
+      options: {
+        page?: string;
+        include?: string;
+        top?: string;
+        json?: boolean;
+      },
+    ) => {
+      try {
+        const code = await analyzeHarCommand(harFile, options);
         process.exit(code);
       } catch (error) {
         console.error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,6 +692,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^2.0.87
         version: 2.0.87(zod@4.2.1)
+      '@babel/parser':
+        specifier: ^7.26.2
+        version: 7.28.5
       '@smappy/core':
         specifier: workspace:*
         version: link:../core
@@ -710,10 +713,19 @@ importers:
       ollama-ai-provider-v2:
         specifier: ^1.5.5
         version: 1.5.5(zod@4.2.1)
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.3
     devDependencies:
+      '@babel/types':
+        specifier: ^7.26.0
+        version: 7.28.5
       '@types/node':
         specifier: ^22.19.0
         version: 22.19.3
+      '@types/picomatch':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@types/webpack':
         specifier: ^5.28.5
         version: 5.28.5
@@ -4615,6 +4627,9 @@ packages:
 
   '@types/pako@2.0.4':
     resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/picomatch@4.0.2':
+    resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
 
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
@@ -13043,6 +13058,8 @@ snapshots:
 
   '@types/pako@2.0.4': {}
 
+  '@types/picomatch@4.0.2': {}
+
   '@types/prismjs@1.26.5': {}
 
   '@types/prop-types@15.7.15': {}
@@ -17987,7 +18004,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.104.0(webpack-cli@5.1.4)
+      webpack: 5.104.0
 
   terser@5.44.1:
     dependencies:


### PR DESCRIPTION
Result for a random Github pull request page - actually a surprising amount of "methods"..? Needs some validation.

```
$ pnpm smappy analyze-har --mode=core ~/Desktop/github.com.har

> smappy@0.0.1 smappy /Users/jankrems/Documents/Code/github.com/hybrist/smappy
> ./libs/cli/src/main.ts analyze-har --mode=core /Users/jankrems/Desktop/github.com.har

Analyzed 207 JavaScript responses (9.4 MB)

Category                Own bytes  % own  Total bytes  % total  Occurrences
----------------------  ---------  -----  -----------  -------  -----------
Functions                  6.4 MB  68.0%       6.7 MB    71.1%        33765
Top-level code             1.7 MB  18.6%       1.7 MB    18.6%          207
Methods                    1.1 MB  11.5%       1.1 MB    11.5%         5750
Object literal methods     162 KB  1.68%       178 KB    1.85%          608
Classes                     18 KB  0.19%       1.1 MB    11.7%          915

Category stats (total bytes)
Category                   Avg  StdDev    P50     P90     P99
----------------------  ------  ------  -----  ------  ------
Functions                275 B  1.9 KB   60 B   527 B  3.0 KB
Methods                  197 B   347 B  100 B   417 B  1.7 KB
Object literal methods   300 B  2.0 KB   76 B   370 B  3.3 KB
Classes                 1.2 KB  2.5 KB  561 B  3.0 KB   11 KB
```